### PR TITLE
Added regexp matching for type alias keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ More advanced flags can be provided for:
   * `--fixNoImplicitAny`/`fixes.noImplicitAny`
   * `--fixStrictNonNullAssertions`/`fixes.strictNonNullAssertions`
 * [Types](./docs/Types.md):
-  * `types.aliases`
-  * `--typesMatching`/`types.matching`
+  * `--typeAlias`/`types.aliases`
+  * `--typeMatching`/`types.matching`
   * `--typeOnlyPrimitives`/`types.onlyPrimitives`
+  * `--typeStrictNullChecks`/`types.strictNullChecks`
 
 ## Node
 

--- a/docs/Types.md
+++ b/docs/Types.md
@@ -7,7 +7,7 @@ Object mapping names of added types to strings to replace them with.
 For example, to replace `null` with `null /* TODO: check auto-generated types (thanks TypeStat!) */`:
 
 ```shell
-typestat --typeAlias null="/* TODO: check added types (thanks TypeStat!) */"
+typestat --typeAlias "null=null /* TODO: check added types (thanks TypeStat!) */"
 ```
 
 ```json
@@ -20,23 +20,27 @@ typestat --typeAlias null="/* TODO: check added types (thanks TypeStat!) */"
 }
 ```
 
+Aliases are interpreted as case-sensitive regular expressions.
+`{0}`s in value replacements will be replaced with the raw matched type.
+
 One strategy is to create a global type alias in your code for each migration to make it _really_ clear these are temporary
 _(and easier to find-all in your IDE)_:
 
 ```typescript
 // typings.d.ts
-type TodoAutoAddedUndefined = undefined;
+type TodoAutoAdded_null = null;
+type TodoAutoAdded_undefined = undefined;
 ```
 
 ```shell
-typestat --typeAlias undefined=TodoAutoAddedUndefined
+typestat --typeAlias "null|undefined=TodoAutoAdded_{0}"
 ```
 
 ```json
 {
     "types": {
         "aliases": {
-            "undefined": "TodoAutoAddedUndefined"
+            "null|undefined": "TodoAutoAdded_{0}"
         }
     }
 }

--- a/src/mutations/typeMutating/createNonNullAssertion.ts
+++ b/src/mutations/typeMutating/createNonNullAssertion.ts
@@ -1,12 +1,11 @@
 import { ITextInsertMutation, ITextSwapMutation } from "automutate";
 import * as ts from "typescript";
+
 import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { findAliasOfType } from "../aliasing";
 
 export const createNonNullAssertion = (request: FileMutationsRequest, node: ts.Node): ITextInsertMutation | ITextSwapMutation => {
-    let assertion = request.options.types.aliases.get("!");
-    if (assertion === undefined) {
-        assertion = "!";
-    }
+    const assertion = findAliasOfType("!", request.options.types.aliases);
 
     // The following node types need to be wrapped in parenthesis to stop the ! from being applied to the wrong (last) element:
     // As expressions: foo as Bar

--- a/src/options/parsing/collectNoImplicitAny.ts
+++ b/src/options/parsing/collectNoImplicitAny.ts
@@ -1,0 +1,24 @@
+import * as ts from "typescript";
+
+import { TypeStatArgv } from "../../index";
+import { RawTypeStatOptions } from "../types";
+
+export const collectNoImplicitAny = (
+    argv: TypeStatArgv,
+    compilerOptions: Readonly<ts.CompilerOptions>,
+    rawOptions: RawTypeStatOptions,
+): boolean => {
+    if (argv.fixNoImplicitAny !== undefined) {
+        return argv.fixNoImplicitAny;
+    }
+
+    if (rawOptions.fixes !== undefined && rawOptions.fixes.noImplicitAny !== undefined) {
+        return rawOptions.fixes.noImplicitAny;
+    }
+
+    if (compilerOptions.noImplicitAny !== undefined) {
+        return compilerOptions.noImplicitAny;
+    }
+
+    return false;
+};

--- a/src/options/parsing/collectStrictNullChecks.ts
+++ b/src/options/parsing/collectStrictNullChecks.ts
@@ -1,0 +1,36 @@
+import * as ts from "typescript";
+
+import { TypeStatArgv } from "../../index";
+import { RawTypeStatTypeOptions } from "../types";
+
+export const collectStrictNullChecks = (
+    argv: TypeStatArgv,
+    compilerOptions: Readonly<ts.CompilerOptions>,
+    rawOptionTypes: RawTypeStatTypeOptions,
+) => {
+    const typeStrictNullChecks =
+        rawOptionTypes.strictNullChecks === undefined ? argv.typeStrictNullChecks : rawOptionTypes.strictNullChecks;
+
+    const compilerStrictNullChecks = collectCompilerStrictNullChecks(compilerOptions, typeStrictNullChecks);
+
+    return { compilerStrictNullChecks, typeStrictNullChecks };
+};
+
+const collectCompilerStrictNullChecks = (
+    compilerOptions: Readonly<ts.CompilerOptions>,
+    typeStrictNullChecks: boolean | undefined,
+): boolean => {
+    if (typeStrictNullChecks !== undefined) {
+        return typeStrictNullChecks;
+    }
+
+    if (compilerOptions.strictNullChecks !== undefined) {
+        return compilerOptions.strictNullChecks;
+    }
+
+    if (compilerOptions.strict !== undefined) {
+        return compilerOptions.strict;
+    }
+
+    return false;
+};

--- a/src/options/parsing/collectTypeAliases.ts
+++ b/src/options/parsing/collectTypeAliases.ts
@@ -1,0 +1,58 @@
+import { TypeStatArgv } from "../../index";
+import { arrayify } from "../../shared/arrays";
+import { convertObjectToMap } from "../../shared/maps";
+import { RawTypeStatTypeOptions } from "../types";
+
+export const collectTypeAliases = (argv: TypeStatArgv, rawOptionTypes: RawTypeStatTypeOptions): ReadonlyMap<RegExp, string> | string => {
+    const rawTypeAliases: Map<string, string> =
+        rawOptionTypes.aliases === undefined ? new Map() : convertObjectToMap(rawOptionTypes.aliases);
+
+    if (argv.typeAlias !== undefined) {
+        for (const rawTypeAlias of arrayify(argv.typeAlias)) {
+            const keyAndValue = splitRawTypeAlias(rawTypeAlias);
+            if (keyAndValue === undefined) {
+                return `Improper type alias: '${rawTypeAlias}'. Format these as '--typeAlias key=value'.`;
+            }
+
+            rawTypeAliases.set(keyAndValue[0], keyAndValue[1]);
+        }
+    }
+
+    const regexTypeAliases = new Map<RegExp, string>();
+
+    for (const [rawMatcher, value] of rawTypeAliases) {
+        try {
+            regexTypeAliases.set(new RegExp(`(.*)${rawMatcher}(.*)`), value);
+        } catch (error) {
+            return `Invalid type alias: '${rawMatcher}' (${error})`;
+        }
+    }
+
+    return regexTypeAliases;
+};
+
+const splitRawTypeAlias = (rawTypeAlias: string): [string, string] | undefined => {
+    const splitIndex = getUnescapedEqualsIndex(rawTypeAlias);
+
+    return splitIndex <= 0 ? undefined : [rawTypeAlias.substring(0, splitIndex), rawTypeAlias.substring(splitIndex + 1)];
+};
+
+const getUnescapedEqualsIndex = (rawTypeAlias: string): number => {
+    let equalsIndex = 0;
+
+    while (true) {
+        equalsIndex = rawTypeAlias.indexOf("=", equalsIndex + 1);
+
+        if (equalsIndex === -1 || equalsIndex === rawTypeAlias.length - 1) {
+            break;
+        }
+
+        if (rawTypeAlias[equalsIndex - 1] === "\\") {
+            continue;
+        }
+
+        return equalsIndex;
+    }
+
+    return -1;
+};

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -154,9 +154,9 @@ export interface Fixes {
  */
 export interface TypeStatTypeOptions {
     /**
-     * Names of added types mapped to strings to replace them with.
+     * Names of added type matchers mapped to strings to replace them with.
      */
-    aliases: ReadonlyMap<string, string>;
+    aliases: ReadonlyMap<RegExp, string>;
 
     /**
      * Glob matchers added types must match, if provided.

--- a/test/cases/types/aliases/types/expected.ts
+++ b/test/cases/types/aliases/types/expected.ts
@@ -5,7 +5,7 @@
         return true;
     }
 
-    function stringOrUndefined(): string | undefined {
+    function stringOrUndefined(): string | undefined /* todo: undefined */ {
         return undefined;
     }
 

--- a/test/cases/types/aliases/types/typestat.json
+++ b/test/cases/types/aliases/types/typestat.json
@@ -4,8 +4,7 @@
     },
     "types": {
         "aliases": {
-            "null": "null /* todo: null */",
-            "undefined": "undefined",
+            "null|undefined": "{0} /* todo: {0} */",
             "Foo": "/* Foo */ Foo"
         },
         "strictNullChecks": true


### PR DESCRIPTION
It's a bit less efficient now that it has to loop through keys each time. I could add a cache but that seems like extra work. Eventually, if performance profiling shows that to be a bad thing, that can happen.

Splits out some pieces of `fillOutRawOptions` into separate files because the one file was getting too big.

Fixes #9.