### PR TITLE
Moved custom/built-in mutation resolving earlier, to option parsing

### DIFF
--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -106,7 +106,7 @@ export interface TypeStatOptions {
     readonly logger: ProcessLogger;
 
     /**
-     * Added mutators specified by the user.
+     * Mutators to run, as either the built-in mutators or custom mutators specified by the user.
      */
     readonly mutators: ReadonlyArray<[string, FileMutator]>;
 

--- a/src/runtime/findMutationsInFile.ts
+++ b/src/runtime/findMutationsInFile.ts
@@ -2,8 +2,7 @@ import { IMutation } from "automutate";
 import chalk from "chalk";
 import { readline } from "mz";
 
-import { builtInFileMutators } from "../mutators/builtInFileMutators";
-import { FileMutationsRequest, FileMutator } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "../mutators/fileMutator";
 
 /**
  * Collects all mutations that should apply to a file.
@@ -13,7 +12,7 @@ export const findMutationsInFile = async (request: FileMutationsRequest): Promis
     request.options.logger.stdout.write(`${checkMessage}\n`);
     let mutations: ReadonlyArray<IMutation> | undefined;
 
-    for (const [mutatorName, mutator] of collectFileMutators(request.options.mutators)) {
+    for (const [mutatorName, mutator] of request.options.mutators) {
         try {
             const addedMutations = mutator(request);
 
@@ -32,6 +31,3 @@ export const findMutationsInFile = async (request: FileMutationsRequest): Promis
     readline.clearLine(request.options.logger.stdout, 1);
     return mutations;
 };
-
-const collectFileMutators = (addedMutators: ReadonlyArray<[string, FileMutator]>): ReadonlyArray<[string, FileMutator]> =>
-    addedMutators.length === 0 ? builtInFileMutators : addedMutators;


### PR DESCRIPTION
As @ian-craig noted, it's a little odd to choose between these things within `findMutationsInFile`. The "which mutations will we apply?" logic should really be part of options parsing. The work to look at the raw options for them is already done in `options/addedMutators.ts`, so this tweaks the logic to default to `builtInFileMutators` instead of an empty array.

Starts on #96.