### PR TITLE
Added auto-installation of missing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ typestat --project tsconfig.strict.json
 }
 ```
 
+If a relative project file path is provided, its absolute path will be resolved from `--packageDirectory`.
+
+### Usage
+
 More advanced flags can be provided for:
 
 * [Files](./docs/Files.md)
@@ -120,6 +124,10 @@ More advanced flags can be provided for:
   * `--fixMissingProperties`/`fixes.missingProperties`
   * `--fixNoImplicitAny`/`fixes.noImplicitAny`
   * `--fixStrictNonNullAssertions`/`fixes.strictNonNullAssertions`
+* [Package](./docs/Package.md):
+  * `--packageDirectory`/`package.directory`
+  * `--packageFile`/`package.file`
+  * `--packageMissingTypes`/`package.missingTypes`
 * [Types](./docs/Types.md):
   * `--typeAlias`/`types.aliases`
   * `--typeMatching`/`types.matching`

--- a/docs/Package.md
+++ b/docs/Package.md
@@ -1,0 +1,130 @@
+# Package
+
+An optional set of CLI flags and/or configuration object fields containing package-level changes to make outside of mutations.
+
+```json
+{
+    "package": {
+        "directory": "../MyRepo",
+        "file": "./node/package.json",
+        "missingTypes": "yarn"
+    }
+}
+```
+
+## `--packageDirectory`/`directory`
+
+```shell
+typestat --packageDirectory "../MyRepo"
+```
+
+```json
+{
+    "package": {
+        "directory": "../MyRepo"
+    }
+}
+```
+
+Base directory to resolve paths from.
+All non-absolute paths within all settings except `-c`/`--config` will be resolved against this directory.
+
+## `--packageFile`/`file`
+
+```shell
+typestat --packageFile "./node/package.json"
+```
+
+```json
+{
+    "package": {
+        "file": "./node/package.json"
+    }
+}
+```
+
+File path to a `package.json` to consider the project's package file.
+If not provided, defaults to `./package.json`.
+
+If `--packageFile` is relative, `--packageDirectory` will be used as a root path to resolve from.
+
+## `--packageMissingTypes`/`missingTypes`
+
+```shell
+typestat --packageMissingTypes
+```
+
+```json
+{
+    "package": {
+        "missingTypes": true
+    }
+}
+```
+
+Package manager to install missing types, if not `true` to auto-detect or `undefined` to not.
+If this is provided, for any `require` or `import` to an absolute path that doesn't have its corresponding [`@types/`](https://github.com/DefinitelyTyped/DefinitelyTyped) package,
+that package will be installed.
+
+For example, if the following code exists in any file within the TypeScript project:
+
+```javascript
+import { array } from "lodash/array";
+```
+
+TypeStat will attempt to install `@types/lodash` unless it's already any form of dependency in the `--packageFile`,
+
+### Package Manager Configuration
+
+This field has four potential allowed configurations:
+
+* `false` _(default)_: skip installing missing packages
+* `true`: auto-detect whether to use Yarn _(if a `yarn.lock` exists)_ or npm _(default)_
+
+    ```shell
+    typestat --packageMissingTypes
+    ```
+
+    ```json
+    {
+        "package": {
+            "missingTypes": true
+        }
+    }
+    ```
+
+* `"npm"`: install using npm
+
+    ```shell
+    typestat --packageMissingTypes npm
+    ```
+
+    ```json
+    {
+        "package": {
+            "missingTypes": "npm"
+        }
+    }
+    ```
+
+* `"yarn"`: install using Yarn
+
+    ```shell
+    typestat --packageMissingTypes yarn
+    ```
+
+    ```json
+    {
+        "package": {
+            "missingTypes": "yarn"
+        }
+    }
+    ```
+
+### Node types
+
+`@types/node` will be installed in any of the following cases:
+
+* `module =`, `module.exports =`, or `module.exports.*` = statement(s) exist
+* [Built-in modules](https://www.npmjs.com/package/builtin-modules) are imported from
+* A global [`process` object](https://nodejs.org/api/process.html#process_process) is referenced

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "@phenomnomnominal/tsquery": "^3.0.0",
         "@types/mz": "0.0.32",
         "automutate": "^0.7.1",
+        "builtin-modules": "^3.0.0",
         "chalk": "^2.4.1",
         "commander": "^2.19.0",
         "cosmiconfig": "^5.0.7",
@@ -16,6 +17,7 @@
     },
     "description": "Adds TypeScript type annotations using static analysis.",
     "devDependencies": {
+        "@types/builtin-modules": "^2.0.0",
         "@types/cosmiconfig": "^5.0.3",
         "@types/glob": "^7.1.1",
         "@types/jest": "^23.3.11",

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -37,6 +37,9 @@ export const runCli = async (rawArgv: ReadonlyArray<string>, runtime = createDef
             "--fixStrictNonNullAssertions",
             "add missing non-null assertions in nullable property accesses, function-like calls, and return types",
         )
+        .option("--packageDirectory [packageDirectory]", "working directory (cwd) of the project")
+        .option("--packageFile [packageFile]", "package.json path to consider the project's package")
+        .option("--packageMissingTypes [packageMissingTypes]", "package manager to install missing types, or unspecified to auto-detect")
         .option("--typeAlias [...typeAlias]", "add a key=value to replace added type names with")
         .option("--typeMatching [...typeMatching]", "regular expression matchers added types must match.")
         .option("--typeStrictNullChecks", "override TypeScript's --strictNullChecks setting for types")

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { loadOptions } from "./options/loadOptions";
 import { findComplaintForOptions } from "./options/optionVerification";
 import { processFileRenames } from "./options/processFileRenames";
 import { TypeStatOptions } from "./options/types";
-import { createTypeStatMutationsProvider } from "./runtime/createTypeStatMutationsProvider";
+import { createTypeStatProvider } from "./runtime/createTypeStatProvider";
 
 /**
  * Root arguments to pass to TypeStat.
@@ -29,6 +29,9 @@ export interface TypeStatArgv {
      */
     readonly logger: ProcessLogger;
 
+    readonly packageDirectory?: string;
+    readonly packageFile?: string;
+    readonly packageMissingTypes?: true | "npm" | "yarn";
     readonly project?: string;
     readonly typeAlias?: string | ReadonlyArray<string>;
     readonly typeMatching?: ReadonlyArray<string>;
@@ -69,7 +72,7 @@ export const typeStat = async (argv: TypeStatArgv): Promise<TypeStatResult> => {
 
     try {
         await runMutations({
-            mutationsProvider: createTypeStatMutationsProvider(options),
+            mutationsProvider: createTypeStatProvider(options),
         });
     } catch (error) {
         return {

--- a/src/options/fillOutRawOptions.ts
+++ b/src/options/fillOutRawOptions.ts
@@ -4,9 +4,10 @@ import { TypeStatArgv } from "../index";
 import { processLogger } from "../logging/logger";
 import { arrayify, collectOptionals } from "../shared/arrays";
 import { collectAsConfiguration } from "../shared/booleans";
-import { collectAddedMutators } from "./addedMutators";
+import { collectAddedMutators } from "./parsing/collectAddedMutators";
 import { collectFileOptions } from "./parsing/collectFileOptions";
 import { collectNoImplicitAny } from "./parsing/collectNoImplicitAny";
+import { collectPackageOptions } from "./parsing/collectPackageOptions";
 import { collectStrictNullChecks } from "./parsing/collectStrictNullChecks";
 import { collectTypeAliases } from "./parsing/collectTypeAliases";
 import { RawTypeStatOptions, TypeStatOptions } from "./types";
@@ -15,6 +16,7 @@ export interface OptionsFromRawOptionsSettings {
     argv: TypeStatArgv;
     compilerOptions: Readonly<ts.CompilerOptions>;
     fileNames?: ReadonlyArray<string>;
+    packageDirectory: string;
     projectPath: string;
     rawOptions: RawTypeStatOptions;
 }
@@ -28,6 +30,7 @@ export const fillOutRawOptions = ({
     argv,
     compilerOptions,
     fileNames,
+    packageDirectory,
     projectPath,
     rawOptions,
 }: OptionsFromRawOptionsSettings): TypeStatOptions | string => {
@@ -39,6 +42,8 @@ export const fillOutRawOptions = ({
     if (typeof typeAliases === "string") {
         return typeAliases;
     }
+
+    const packageOptions = collectPackageOptions(argv, packageDirectory, rawOptions);
 
     const options = {
         compilerOptions: {
@@ -58,7 +63,8 @@ export const fillOutRawOptions = ({
             ...rawOptions.fixes,
         },
         logger: argv.logger,
-        mutators: collectAddedMutators(argv, rawOptions, processLogger),
+        mutators: collectAddedMutators(argv, rawOptions, packageOptions.directory, processLogger),
+        package: packageOptions,
         projectPath,
         types: {
             aliases: typeAliases,

--- a/src/options/findRawOptions.ts
+++ b/src/options/findRawOptions.ts
@@ -24,22 +24,39 @@ export interface FoundRawOptions {
 /**
  * Parses raw options from a configuration file, using Cosmiconfig to find it if necessary.
  *
+ * @param packageDirectory   Base directory to resolve paths from.
  * @param configPath   Suggested path to load from, instead of searching.
  * @returns Promise for parsed raw options from a configuration file.
  * @remarks This defaults to tsconfig.json in the local directory.
  */
-export const findRawOptions = async (configPath?: string): Promise<FoundRawOptions> => {
+export const findRawOptions = async (packageDirectory: string, configPath?: string): Promise<FoundRawOptions> => {
     const explorer = cosmiconfig("typestat");
     const cosmiconfigResult = configPath === undefined ? await explorer.search() : await explorer.load(configPath);
 
     return cosmiconfigResult === null
         ? {
               rawOptions: {
-                  projectPath: normalizeAndSlashify(path.join(process.cwd(), "tsconfig.json")),
+                  projectPath: normalizeAndSlashify(path.join(packageDirectory, "tsconfig.json")),
               },
           }
         : {
               filePath: cosmiconfigResult.filepath,
-              rawOptions: cosmiconfigResult.config as RawTypeStatOptions,
+              rawOptions: extractConfigAsRelative(cosmiconfigResult),
           };
+};
+
+const extractConfigAsRelative = (cosmiconfigResult: NonNullable<cosmiconfig.CosmiconfigResult>): RawTypeStatOptions => {
+    let config = cosmiconfigResult.config as RawTypeStatOptions;
+
+    if (config.package !== undefined && config.package.directory !== undefined && !path.isAbsolute(config.package.directory)) {
+        config = {
+            ...config,
+            package: {
+                ...config.package,
+                directory: path.join(cosmiconfigResult.filepath, config.package.directory),
+            },
+        };
+    }
+
+    return config;
 };

--- a/src/options/parsing/collectAddedMutators.ts
+++ b/src/options/parsing/collectAddedMutators.ts
@@ -1,12 +1,12 @@
 import * as path from "path";
 
-import { TypeStatArgv } from "../index";
-import { ProcessLogger } from "../logging/logger";
-import { builtInFileMutators } from "../mutators/builtInFileMutators";
-import { FileMutator } from "../mutators/fileMutator";
-import { arrayify, collectOptionals } from "../shared/arrays";
-import { getQuickErrorSummary } from "../shared/errors";
-import { RawTypeStatOptions } from "./types";
+import { TypeStatArgv } from "../../index";
+import { ProcessLogger } from "../../logging/logger";
+import { builtInFileMutators } from "../../mutators/builtInFileMutators";
+import { FileMutator } from "../../mutators/fileMutator";
+import { arrayify, collectOptionals } from "../../shared/arrays";
+import { getQuickErrorSummary } from "../../shared/errors";
+import { RawTypeStatOptions } from "../types";
 
 interface ImportedFileMutator {
     fileMutator: FileMutator;
@@ -17,12 +17,14 @@ interface ImportedFileMutator {
  *
  * @param argv   Root arguments to pass to TypeStat.
  * @param rawOptions   Options listed as JSON in a typestat configuration file.
+ * @param packageDirectory   Base directory to resolve paths from.
  * @param logger   Wraps process.stderr and process.stdout.
  * @returns Mutators to run with their friendly names.
  */
 export const collectAddedMutators = (
     argv: TypeStatArgv,
     rawOptions: RawTypeStatOptions,
+    packageDirectory: string,
     logger: ProcessLogger,
 ): ReadonlyArray<[string, FileMutator]> => {
     const addedMutators = collectOptionals(arrayify(argv.mutator), rawOptions.mutators);
@@ -31,17 +33,15 @@ export const collectAddedMutators = (
     }
 
     const additions: [string, FileMutator][] = [];
-    const baseOptionsDir = rawOptions.projectPath === undefined ? process.cwd() : path.dirname(rawOptions.projectPath);
-
     for (const rawAddedMutator of addedMutators) {
         try {
-            const addedMutator = collectAddedMutator(baseOptionsDir, rawAddedMutator, logger);
+            const addedMutator = collectAddedMutator(packageDirectory, rawAddedMutator, logger);
 
             if (addedMutator !== undefined) {
                 additions.push([rawAddedMutator, addedMutator]);
             }
         } catch (error) {
-            logger.stderr.write(`Could not require ${rawAddedMutator} from ${baseOptionsDir}.\n`);
+            logger.stderr.write(`Could not require ${rawAddedMutator} from ${packageDirectory}.\n`);
             logger.stderr.write(getQuickErrorSummary(error));
         }
     }

--- a/src/options/parsing/collectPackageOptions.ts
+++ b/src/options/parsing/collectPackageOptions.ts
@@ -1,0 +1,22 @@
+import * as path from "path";
+
+import { TypeStatArgv } from "../../index";
+import { normalizeAndSlashify } from "../../shared/paths";
+import { Package, RawTypeStatOptions } from "../types";
+
+export const collectPackageOptions = (argv: TypeStatArgv, packageDirectory: string, rawOptions: RawTypeStatOptions): Package => {
+    const rawPackageOptions = rawOptions.package === undefined ? {} : rawOptions.package;
+
+    const rawPackageFile = argv.packageFile === undefined ? rawPackageOptions.file : argv.packageFile;
+
+    const file =
+        rawPackageFile === undefined || path.isAbsolute(rawPackageFile)
+            ? normalizeAndSlashify(path.join(packageDirectory, "package.json"))
+            : normalizeAndSlashify(rawPackageFile);
+
+    return {
+        directory: packageDirectory,
+        file,
+        missingTypes: argv.packageMissingTypes === undefined ? rawPackageOptions.missingTypes : argv.packageMissingTypes,
+    };
+};

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -36,14 +36,19 @@ export interface RawTypeStatOptions {
     readonly mutators?: ReadonlyArray<string>;
 
     /**
-     * Options for which types to add under what aliases.
+     * Directives for project-level changes.
      */
-    readonly types?: RawTypeStatTypeOptions;
+    readonly package?: Readonly<Partial<Package>>;
 
     /**
      * Path to a TypeScript configuration file, if not "tsconfig.json".
      */
     readonly projectPath?: string;
+
+    /**
+     * Options for which types to add under what aliases.
+     */
+    readonly types?: RawTypeStatTypeOptions;
 }
 
 /**
@@ -111,14 +116,19 @@ export interface TypeStatOptions {
     readonly mutators: ReadonlyArray<[string, FileMutator]>;
 
     /**
-     * Options for which types to add under what aliases.
+     * Directives for project-level changes.
      */
-    readonly types: TypeStatTypeOptions;
+    readonly package: Readonly<Package>;
 
     /**
      * Path to a tsconfig.json file.
      */
     readonly projectPath: string;
+
+    /**
+     * Options for which types to add under what aliases.
+     */
+    readonly types: TypeStatTypeOptions;
 }
 
 /**
@@ -177,6 +187,26 @@ export interface Fixes {
      * Whether to add missing non-null assertions in nullable property accesses, function-like calls, and return types.
      */
     strictNonNullAssertions: boolean;
+}
+
+/**
+ * Directives for package-level changes.
+ */
+export interface Package {
+    /**
+     * Working directory to base paths off of.
+     */
+    directory: string;
+
+    /**
+     * Path to a package.json to consider the project's package.
+     */
+    file: string;
+
+    /**
+     * Package manager to install missing types, if not `true` to auto-detect or `undefined` to not.
+     */
+    missingTypes: true | "npm" | "yarn" | undefined;
 }
 
 /**

--- a/src/runtime/createProviderFromProviders.ts
+++ b/src/runtime/createProviderFromProviders.ts
@@ -1,5 +1,11 @@
 import { IMutationsWave } from "automutate";
 
+/**
+ * Creates a provider that runs through a series of providers.
+ *
+ * @param providers   Providers to return changes from, in order.
+ * @returns Single provider equivalent to the given providers, in order.
+ */
 export const createProviderFromProviders = (...providers: (() => Promise<IMutationsWave>)[]) => {
     let index = 0;
 

--- a/src/runtime/createSingleUserProvider.ts
+++ b/src/runtime/createSingleUserProvider.ts
@@ -1,0 +1,23 @@
+import { IMutationsWave } from "automutate";
+
+/**
+ * Creates a provider that will run exactly once.
+ *
+ * @param provider   Provider to wrap around.
+ * @returns Single-use equivalent of the provider.
+ */
+export const createSingleUseProvider = (provider: () => Promise<IMutationsWave>) => {
+    let provided = false;
+
+    return async (): Promise<IMutationsWave> => {
+        if (provided) {
+            return {
+                fileMutations: undefined,
+            };
+        }
+
+        provided = true;
+
+        return provider();
+    };
+};

--- a/src/runtime/createTypeStatProvider.ts
+++ b/src/runtime/createTypeStatProvider.ts
@@ -3,17 +3,19 @@ import { IMutationsProvider } from "automutate";
 import { TypeStatOptions } from "../options/types";
 import { createProviderFromProviders } from "./createProviderFromProviders";
 import { createCoreMutationsProvider } from "./providers/createCoreMutationsProvider";
+import { createInstallMissingTypesProvider } from "./providers/createInstallMissingTypesProvider";
 import { createMarkFilesModifiedProvider } from "./providers/createMarkFilesModifiedProvider";
 import { createRequireRenameProvider } from "./providers/createRequireRenameProvider";
 
 /**
  * Creates a mutations provider that mutates files, then marks them as mutated.
  */
-export const createTypeStatMutationsProvider = (options: TypeStatOptions): IMutationsProvider => {
+export const createTypeStatProvider = (options: TypeStatOptions): IMutationsProvider => {
     const allModifiedFiles = new Set<string>();
 
     return {
         provide: createProviderFromProviders(
+            createInstallMissingTypesProvider(options),
             createRequireRenameProvider(options, allModifiedFiles),
             createCoreMutationsProvider(options, allModifiedFiles),
             createMarkFilesModifiedProvider(options, allModifiedFiles),

--- a/src/runtime/providers/createInstallMissingTypesProvider.ts
+++ b/src/runtime/providers/createInstallMissingTypesProvider.ts
@@ -1,0 +1,59 @@
+import { IMutationsWave } from "automutate";
+import * as builtinModules from "builtin-modules";
+
+import { TypeStatOptions } from "../../options/types";
+import { normalizeAndSlashify } from "../../shared/paths";
+import { setSubtract } from "../../shared/sets";
+import { createFileNamesAndServices } from "../createFileNamesAndServices";
+import { createSingleUseProvider } from "../createSingleUserProvider";
+import { collectExistingTypingPackages } from "./missingTypes/collectExistingTypingPackages";
+import { collectPackageManagerRunner } from "./missingTypes/collectPackageManagerRunner";
+import { collectReferencedPackageNames } from "./missingTypes/collectReferencedPackageNames";
+import { filterTypedPackageNames } from "./missingTypes/filterTypedPackageNames";
+
+const uniqueBuiltinModules = new Set(builtinModules);
+
+/**
+ * Creates a mutations provider that installs missing types modules.
+ *
+ * @param options   Parsed runtime options for TypeStat.
+ * @returns Provider to install missing types modules.
+ */
+export const createInstallMissingTypesProvider = (options: TypeStatOptions) => {
+    const installMissingTypes = async () => {
+        if (options.package.missingTypes === undefined) {
+            return;
+        }
+
+        // Collect package names already present in the package file
+        const existingPackageNames = await collectExistingTypingPackages(options, options.package.file);
+        if (existingPackageNames === undefined) {
+            return;
+        }
+
+        // Collect every package name referenced by every file in the project
+        const { services } = createFileNamesAndServices(options);
+        const referencedPackageNames = collectReferencedPackageNames(services);
+
+        // Ignore package names already referenced in package.json or that don't exist in DefinitelyTyped
+        const missingPackageNames = setSubtract(referencedPackageNames, new Set(existingPackageNames), uniqueBuiltinModules);
+        const missingTypedPackageNames = await filterTypedPackageNames(Array.from(missingPackageNames));
+        if (missingTypedPackageNames.length === 0) {
+            return;
+        }
+
+        // Run the installation command using the requested or detected package manager
+        const packageManagerRunner = await collectPackageManagerRunner(options, options.package.file, options.package.missingTypes);
+        await packageManagerRunner(options, missingTypedPackageNames);
+    };
+
+    return createSingleUseProvider(
+        async (): Promise<IMutationsWave> => {
+            await installMissingTypes();
+
+            return {
+                fileMutations: undefined,
+            };
+        },
+    );
+};

--- a/src/runtime/providers/createMarkFilesModifiedProvider.ts
+++ b/src/runtime/providers/createMarkFilesModifiedProvider.ts
@@ -3,6 +3,7 @@ import * as fs from "mz/fs";
 import { EOL } from "os";
 
 import { TypeStatOptions } from "../../options/types";
+import { createSingleUseProvider } from "../createSingleUserProvider";
 
 /**
  * Creates a mutations wave to mark all previously mutated files as modified.
@@ -12,23 +13,23 @@ import { TypeStatOptions } from "../../options/types";
  * @returns Mutations wave marking all mutated files as modified.
  */
 export const createMarkFilesModifiedProvider = (options: TypeStatOptions, allModifiedFileNames: ReadonlySet<string>) => {
-    let provided = false;
-    return async (): Promise<IMutationsWave> => {
-        if (provided || (options.files.above === "" && options.files.below === "")) {
-            return {
-                fileMutations: undefined,
-            };
-        }
+    return createSingleUseProvider(
+        async (): Promise<IMutationsWave> => {
+            if (options.files.above === "" && options.files.below === "") {
+                return {
+                    fileMutations: undefined,
+                };
+            }
 
-        const fileMutations: IFileMutations = {};
-        provided = true;
+            const fileMutations: IFileMutations = {};
 
-        for (const fileName of allModifiedFileNames) {
-            fileMutations[fileName] = await createFileMutations(options, fileName);
-        }
+            for (const fileName of allModifiedFileNames) {
+                fileMutations[fileName] = await createFileMutations(options, fileName);
+            }
 
-        return { fileMutations };
-    };
+            return { fileMutations };
+        },
+    );
 };
 
 const createFileMutations = async (options: TypeStatOptions, fileName: string): Promise<ITextInsertMutation[]> => {

--- a/src/runtime/providers/createRequireRenameProvider.ts
+++ b/src/runtime/providers/createRequireRenameProvider.ts
@@ -4,51 +4,50 @@ import { findRequireRenameMutationsInFile } from "../../mutations/renames/findRe
 import { TypeStatOptions } from "../../options/types";
 import { convertMapToObject, Dictionary } from "../../shared/maps";
 import { createFileNamesAndServices } from "../createFileNamesAndServices";
+import { createSingleUseProvider } from "../createSingleUserProvider";
 
 /**
- * Creates a mutations provider that runs the core mutations within TypeStat.
+ * Creates a mutations provider that transforms local require() calls in files.
  *
  * @param options   Parsed runtime options for TypeStat.
  * @param allModifiedFileNames   Set to mark names of all files that were modified.
  */
 export const createRequireRenameProvider = (options: TypeStatOptions, allModifiedFiles: Set<string>) => {
-    let needsToProvide = options.files.renameExtensions;
+    return createSingleUseProvider(
+        async (): Promise<IMutationsWave> => {
+            if (!options.files.renameExtensions) {
+                return {
+                    fileMutations: undefined,
+                };
+            }
 
-    return async (): Promise<IMutationsWave> => {
-        if (!needsToProvide) {
+            const fileMutations = new Map<string, ReadonlyArray<IMutation>>();
+            const { fileNames, services } = createFileNamesAndServices(options);
+            const allFileNames = new Set(fileNames);
+
+            for (const fileName of fileNames) {
+                const sourceFile = services.program.getSourceFile(fileName);
+                if (sourceFile === undefined) {
+                    options.logger.stderr.write(`Could not find TypeScript source file for '${fileName}'.\n`);
+                    continue;
+                }
+
+                const foundMutations = findRequireRenameMutationsInFile({
+                    allFileNames,
+                    options,
+                    services,
+                    sourceFile,
+                });
+
+                if (foundMutations.length !== 0) {
+                    allModifiedFiles.add(fileName);
+                    fileMutations.set(fileName, foundMutations);
+                }
+            }
+
             return {
-                fileMutations: undefined,
+                fileMutations: fileMutations.size === 0 ? undefined : (convertMapToObject(fileMutations) as Dictionary<IMutation[]>),
             };
-        }
-
-        needsToProvide = false;
-
-        const fileMutations = new Map<string, ReadonlyArray<IMutation>>();
-        const { fileNames, services } = createFileNamesAndServices(options);
-        const allFileNames = new Set(fileNames);
-
-        for (const fileName of fileNames) {
-            const sourceFile = services.program.getSourceFile(fileName);
-            if (sourceFile === undefined) {
-                options.logger.stderr.write(`Could not find TypeScript source file for '${fileName}'.\n`);
-                continue;
-            }
-
-            const foundMutations = findRequireRenameMutationsInFile({
-                allFileNames,
-                options,
-                services,
-                sourceFile,
-            });
-
-            if (foundMutations.length !== 0) {
-                allModifiedFiles.add(fileName);
-                fileMutations.set(fileName, foundMutations);
-            }
-        }
-
-        return {
-            fileMutations: fileMutations.size === 0 ? undefined : (convertMapToObject(fileMutations) as Dictionary<IMutation[]>),
-        };
-    };
+        },
+    );
 };

--- a/src/runtime/providers/missingTypes/collectExistingTypingPackages.ts
+++ b/src/runtime/providers/missingTypes/collectExistingTypingPackages.ts
@@ -1,0 +1,43 @@
+import { fs } from "mz";
+
+import { TypeStatOptions } from "../../../options/types";
+import { getQuickErrorSummary } from "../../../shared/errors";
+
+export const collectExistingTypingPackages = async (options: TypeStatOptions, packagePath: string) => {
+    const allDependencies = await tryCollectAllDependencies(packagePath);
+    if (typeof allDependencies === "string") {
+        options.logger.stderr.write(`\nError trying to collect existing dependencies for --packageMissingTypes:\n\t`);
+        options.logger.stderr.write(allDependencies);
+        options.logger.stderr.write("\n\n");
+        return undefined;
+    }
+
+    return Array.from(allDependencies)
+        .filter((dependency) => dependency.startsWith("@types/"))
+        .map((dependency) => dependency.substring("@types/".length));
+};
+
+const tryCollectAllDependencies = async (packagePath: string) => {
+    try {
+        return collectAllDependencies(packagePath);
+    } catch (error) {
+        return getQuickErrorSummary(error);
+    }
+};
+
+const collectAllDependencies = async (packagePath: string) => {
+    const rawContents = (await fs.readFile(packagePath)).toString();
+    const parsedContents = JSON.parse(rawContents) as { [i: string]: { [i: string]: string } | undefined };
+
+    const allDependencies: string[] = [];
+
+    for (const groupName of ["dependencies", "devDependencies", "peerDependencies"]) {
+        const packageObject = parsedContents[groupName];
+
+        if (packageObject !== undefined) {
+            allDependencies.push(...Object.keys(packageObject));
+        }
+    }
+
+    return new Set(allDependencies);
+};

--- a/src/runtime/providers/missingTypes/collectPackageManagerRunner.ts
+++ b/src/runtime/providers/missingTypes/collectPackageManagerRunner.ts
@@ -1,0 +1,18 @@
+import { fs } from "mz";
+import * as path from "path";
+
+import { TypeStatOptions } from "../../../options/types";
+import { installWithNpm } from "./installWithNpm";
+import { installWithYarn } from "./installWithYarn";
+
+export const collectPackageManagerRunner = async (options: TypeStatOptions, missingTypes: true | "npm" | "yarn") => {
+    if (missingTypes === "npm") {
+        return installWithNpm;
+    }
+
+    if (missingTypes === "yarn" || (await fs.exists(path.join(options.package.directory, "yarn.lock")))) {
+        return installWithYarn;
+    }
+
+    return installWithNpm;
+};

--- a/src/runtime/providers/missingTypes/collectReferencedPackageNames.ts
+++ b/src/runtime/providers/missingTypes/collectReferencedPackageNames.ts
@@ -1,0 +1,94 @@
+import * as ts from "typescript";
+
+import { LanguageServices } from "../../../services/language";
+
+export const collectReferencedPackageNames = (services: LanguageServices) => {
+    const packageNames = new Set<string>();
+
+    for (const sourceFile of services.program.getSourceFiles()) {
+        for (const packageName of collectFileReferencedPackageNames(sourceFile)) {
+            packageNames.add(packageName);
+        }
+    }
+
+    return packageNames;
+};
+
+const collectFileReferencedPackageNames = (sourceFile: ts.SourceFile) => {
+    const packageNames = new Set<string>();
+
+    const visitNode = (node: ts.Node) => {
+        const packageName = parsePackageNameFromNode(node);
+
+        if (packageName !== undefined) {
+            packageNames.add(packageName);
+        }
+
+        ts.forEachChild(node, visitNode);
+    };
+
+    ts.forEachChild(sourceFile, visitNode);
+
+    return packageNames;
+};
+
+const parsePackageNameFromNode = (node: ts.Node) => {
+    if (ts.isIdentifier(node) && (node.text === "module" || node.text === "process")) {
+        return "node";
+    }
+
+    if (ts.isImportDeclaration(node)) {
+        return parseImportDeclarationPackageName(node);
+    }
+
+    if (ts.isImportEqualsDeclaration(node)) {
+        return parseImportEqualsDeclarationPackageName(node);
+    }
+
+    if (ts.isCallExpression(node)) {
+        return parseCallExpressionPackageName(node);
+    }
+
+    return undefined;
+};
+
+const parseImportDeclarationPackageName = (node: ts.ImportDeclaration) => parseModuleSpecifier(node.moduleSpecifier);
+
+const parseImportEqualsDeclarationPackageName = (node: ts.ImportEqualsDeclaration) => {
+    const { moduleReference } = node;
+    if (!ts.isExternalModuleReference(moduleReference)) {
+        return undefined;
+    }
+
+    return parseModuleSpecifier(moduleReference.expression);
+};
+
+const parseCallExpressionPackageName = (node: ts.CallExpression) => {
+    if (
+        !ts.isIdentifier(node.expression) ||
+        (node.expression.text !== "import" && node.expression.text !== "require") ||
+        node.arguments.length !== 1
+    ) {
+        return undefined;
+    }
+
+    const firstArgument = node.arguments[0];
+    if (!ts.isStringLiteral(firstArgument)) {
+        return undefined;
+    }
+
+    return parseModuleSpecifier(firstArgument);
+};
+
+const parseModuleSpecifier = (node: ts.Expression) => {
+    if (!ts.isStringLiteral(node)) {
+        return undefined;
+    }
+
+    const { text } = node;
+    if (text[0].match(/[aZ]/) === null) {
+        return undefined;
+    }
+
+    return text.split("/")[0];
+};

--- a/src/runtime/providers/missingTypes/filterTypedPackageNames.ts
+++ b/src/runtime/providers/missingTypes/filterTypedPackageNames.ts
@@ -1,0 +1,21 @@
+import * as https from "https";
+
+/**
+ * Removes package names that don't have a corresponding DefinitelyTyped package.
+ *
+ * @param packageNames   Package names to filter.
+ * @returns Promise for just the package names with a corresponding DefinitelyTyped package.
+ */
+export const filterTypedPackageNames = async (packageNames: ReadonlyArray<string>) => {
+    const processedPackageNames = await Promise.all(packageNames.map(filterTypedPackageName));
+
+    return processedPackageNames.filter((packageName) => packageName !== undefined) as string[];
+};
+
+const filterTypedPackageName = async (packageName: string): Promise<string | undefined> => {
+    return new Promise((resolve) => {
+        https.get(`https://www.npmjs.com/package/@types/${packageName}`, (result) => {
+            resolve(result.statusCode === 200 ? packageName : undefined);
+        });
+    });
+};

--- a/src/runtime/providers/missingTypes/installWithNpm.ts
+++ b/src/runtime/providers/missingTypes/installWithNpm.ts
@@ -1,0 +1,20 @@
+import { TypeStatOptions } from "../../../options/types";
+import { runCommand } from "./runCommand";
+
+export const installWithNpm = async (
+    options: TypeStatOptions,
+    missingPackageNames: ReadonlyArray<string>) => {
+        console.log({ missingPackageNames });
+        console.log(missingPackageNames.map(p => `@types/${p}`));
+        console.log(missingPackageNames.map(p => `@types/${p}`).join(""));
+    await runCommand(
+        options,
+        [
+            "npm",
+            "install",
+            ...Array.from(missingPackageNames)
+                .map((packageName) => `@types/${packageName}`),
+            "-D",
+        ].join(" "),
+    ); 
+};

--- a/src/runtime/providers/missingTypes/installWithYarn.ts
+++ b/src/runtime/providers/missingTypes/installWithYarn.ts
@@ -1,0 +1,9 @@
+import { TypeStatOptions } from "../../../options/types";
+import { runCommand } from "./runCommand";
+
+export const installWithYarn = async (options: TypeStatOptions, missingPackageNames: ReadonlyArray<string>) => {
+    await runCommand(
+        options,
+        ["yarn", "add", ...Array.from(missingPackageNames).map((packageName) => `@types/${packageName}`), "-D"].join(" "),
+    );
+};

--- a/src/runtime/providers/missingTypes/runCommand.ts
+++ b/src/runtime/providers/missingTypes/runCommand.ts
@@ -1,0 +1,39 @@
+import chalk from "chalk";
+import { spawn } from "child_process";
+
+import { TypeStatOptions } from "../../../options/types";
+
+const isWindows = () => process.platform === "win32";
+
+const commandAliases = new Map([["npm", isWindows() ? "npm.cmd" : undefined], ["yarn", isWindows() ? "yarn.cmd" : undefined]]);
+
+/**
+ * Runs a shell command.
+ *
+ * @param fullCommand   Command to spawnute, including args.
+ * @returns Promise for the result code of the command.
+ */
+export const runCommand = async (options: TypeStatOptions, fullCommand: string) => {
+    const [command, ...args] = fullCommand.split(" ");
+    const commandAlias = getCommandAlias(command);
+
+    options.logger.stdout.write(chalk.grey(`> ${commandAlias} ${args.join(" ")}\n`));
+
+    return new Promise<number>(
+        (resolve, reject): void => {
+            const childProcess = spawn(commandAlias, args, {
+                cwd: options.package.directory,
+                stdio: "inherit",
+            });
+
+            childProcess.on("error", reject);
+            childProcess.on("close", resolve);
+        },
+    );
+};
+
+const getCommandAlias = (command: string): string => {
+    const alias = commandAliases.get(command);
+
+    return alias === undefined ? command : alias;
+};

--- a/src/services/language.ts
+++ b/src/services/language.ts
@@ -24,7 +24,7 @@ export const createLanguageServices = (options: TypeStatOptions): LanguageServic
     const servicesHost: ts.LanguageServiceHost = {
         fileExists: ts.sys.fileExists,
         getCompilationSettings: () => options.compilerOptions,
-        getCurrentDirectory: () => process.cwd(),
+        getCurrentDirectory: () => options.package.directory,
         getDefaultLibFileName: ts.getDefaultLibFilePath,
         getScriptFileNames: () => fileNames,
         getScriptSnapshot: (fileName) =>

--- a/src/shared/sets.ts
+++ b/src/shared/sets.ts
@@ -1,9 +1,11 @@
-export const setSubtract = <T>(whole: ReadonlySet<T>, removals: ReadonlySet<T>): Set<T> => {
-    const result = new Set<T>();
+export const setSubtract = <T>(whole: ReadonlySet<T>, ...removals: ReadonlySet<T>[]): Set<T> => {
+    const result = new Set<T>(whole);
 
-    for (const item of whole) {
-        if (!removals.has(item)) {
-            result.add(item);
+    for (const removal of removals) {
+        for (const item of result) {
+            if (removal.has(item)) {
+                result.delete(item);
+            }
         }
     }
 

--- a/src/tests/runTests.ts
+++ b/src/tests/runTests.ts
@@ -6,7 +6,7 @@ import * as ts from "typescript";
 
 import { fillOutRawOptions } from "../options/fillOutRawOptions";
 import { RawTypeStatOptions, TypeStatOptions } from "../options/types";
-import { createTypeStatMutationsProvider } from "../runtime/createTypeStatMutationsProvider";
+import { createTypeStatProvider } from "../runtime/createTypeStatProvider";
 import { arrayify } from "../shared/arrays";
 import { FakeWritableStream } from "./FakeWritableStream";
 
@@ -41,10 +41,11 @@ describeMutationTestCases(
             stdout: new FakeWritableStream(),
         };
 
-        return createTypeStatMutationsProvider({
+        return createTypeStatProvider({
             ...(fillOutRawOptions({
                 argv: { logger },
                 compilerOptions,
+                packageDirectory: __dirname,
                 projectPath,
                 rawOptions: {
                     ...rawOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,11 @@
   dependencies:
     esquery "^1.0.1"
 
+"@types/builtin-modules@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/builtin-modules/-/builtin-modules-2.0.0.tgz#ac89b765b8ef36f0d5ab42de10e39faa5fd64535"
+  integrity sha512-PqWStSS9WSjbJwG62v3AG+hjBdd1zDbQsclXOL+9CRV8nvXwRWv48cZDlSj/mR05Nk/69LV7Ca2onJBi3z2/wA==
+
 "@types/cosmiconfig@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@types/cosmiconfig/-/cosmiconfig-5.0.3.tgz#880644bb155d4038d3b752159684b777b0a159dd"
@@ -569,6 +574,11 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
+
+builtin-modules@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.0.0.tgz#1e587d44b006620d90286cc7a9238bbc6129cab1"
+  integrity sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==
 
 cache-base@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #102.

Adds a whole new section of configuration, `package`. This contains `directory` and/or `file` and/or `missingTypes` settings. The directory one is interesting because now other things will be relative to it. These are necessary in the context of the change because the package file needs to be read from and a `yarn.lock` in the directory is necessary to auto-detect Yarn.

Wowee would it be nice to get the test harness able to support cross-file changes and resets...