### PR TITLE
Added functional component support to react component logic

### DIFF
--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 import { AssignedTypesByName } from "../../../../../mutations/expansions/expansionMutations";
 import { findNodeByStartingPosition } from "../../../../../shared/nodes";
 import { FileMutationsRequest } from "../../../../fileMutator";
-import { ReactComponentNode } from "../reactFiltering/isVisitableComponentClass";
+import { ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 /**
  * Finds all assigned types for properties in each JSX usage of a React component.
@@ -12,7 +12,7 @@ export const getComponentAssignedTypesFromUsage = (
     request: FileMutationsRequest,
     node: ReactComponentNode,
 ): AssignedTypesByName[] | undefined => {
-    const references = request.fileInfoCache.getNodeReferences(node);
+    const references = getComponentReferences(request, node);
     if (references === undefined) {
         return undefined;
     }
@@ -25,6 +25,14 @@ export const getComponentAssignedTypesFromUsage = (
     }
 
     return assignedTypes;
+};
+
+const getComponentReferences = (request: FileMutationsRequest, node: ReactComponentNode) => {
+    if (ts.isClassDeclaration(node) || ts.isFunctionDeclaration(node)) {
+        return request.fileInfoCache.getNodeReferences(node);
+    }
+
+    return request.fileInfoCache.getNodeReferences(node.parent);
 };
 
 const updateAssignedTypesForReference = (

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 
 import { getClassExtendsType } from "../../../../../shared/nodes";
 import { FileMutationsRequest } from "../../../../fileMutator";
-import { ReactComponentNode, ReactFunctionalComponentNode, ReactClassComponentNode } from "../reactFiltering/isReactComponentNode";
+import { ReactClassComponentNode, ReactComponentNode, ReactFunctionalComponentNode } from "../reactFiltering/isReactComponentNode";
 
 export type ReactComponentPropsNode = ts.InterfaceDeclaration | ts.TypeLiteralNode;
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 
 import { getClassExtendsType } from "../../../../../shared/nodes";
 import { FileMutationsRequest } from "../../../../fileMutator";
-import { ReactComponentNode } from "../reactFiltering/isVisitableComponentClass";
+import { ReactComponentNode, ReactFunctionalComponentNode, ReactClassComponentNode } from "../reactFiltering/isReactComponentNode";
 
 export type ReactComponentPropsNode = ts.InterfaceDeclaration | ts.TypeLiteralNode;
 
@@ -10,6 +10,12 @@ export type ReactComponentPropsNode = ts.InterfaceDeclaration | ts.TypeLiteralNo
  * Finds the corresponding interface or type literal that declares a component's props type, if it exists.
  */
 export const getComponentPropsNode = (request: FileMutationsRequest, node: ReactComponentNode): ReactComponentPropsNode | undefined => {
+    return ts.isClassDeclaration(node) || ts.isClassExpression(node)
+        ? getClassComponentPropsNode(request, node)
+        : getFunctionalComponentPropsNode(request, node);
+};
+
+const getClassComponentPropsNode = (request: FileMutationsRequest, node: ReactClassComponentNode): ReactComponentPropsNode | undefined => {
     const extendsType = getClassExtendsType(node);
     if (extendsType === undefined || extendsType.typeArguments === undefined || extendsType.typeArguments.length === 0) {
         return undefined;
@@ -25,6 +31,27 @@ export const getComponentPropsNode = (request: FileMutationsRequest, node: React
     const declaration = propsNodeSymbol.declarations.length === 0 ? undefined : propsNodeSymbol.declarations[0];
 
     return declaration !== undefined && isReactComponentPropsNode(declaration) ? declaration : undefined;
+};
+
+const getFunctionalComponentPropsNode = (
+    request: FileMutationsRequest,
+    node: ReactFunctionalComponentNode,
+): ReactComponentPropsNode | undefined => {
+    const { parameters } = node;
+    if (parameters.length !== 1) {
+        return undefined;
+    }
+
+    const [parameter] = parameters;
+    const type = request.services.program.getTypeChecker().getTypeAtLocation(parameter);
+    const symbol = type.getSymbol();
+    if (symbol === undefined || symbol.declarations.length === 0) {
+        return undefined;
+    }
+
+    const [declaration] = symbol.declarations;
+
+    return isReactComponentPropsNode(declaration) ? declaration : undefined;
 };
 
 const isReactComponentPropsNode = (node: ts.Node): node is ReactComponentPropsNode =>

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/index.ts
@@ -1,7 +1,7 @@
 import { createTypeExpansionMutation } from "../../../../../mutations/expansions/expansionMutations";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
-import { isVisitableComponentNode, ReactComponentNode } from "../reactFiltering/isVisitableComponentClass";
+import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 import { getComponentAssignedTypesFromUsage } from "./getComponentAssignedTypesFromUsage";
 import { getComponentPropsNode } from "./getComponentPropsNode";
@@ -10,10 +10,10 @@ import { getComponentPropsNode } from "./getComponentPropsNode";
  * Expands the existing props type for a component from its usages.
  */
 export const fixReactPropsFromLaterAssignments: FileMutator = (request) => {
-    return collectMutationsFromNodes(request, isVisitableComponentNode, visitClassDeclaration);
+    return collectMutationsFromNodes(request, isReactComponentNode, visitReactComponentNode);
 };
 
-const visitClassDeclaration = (node: ReactComponentNode, request: FileMutationsRequest) => {
+const visitReactComponentNode = (node: ReactComponentNode, request: FileMutationsRequest) => {
     // Grab the node used to declare the node's props type, if it exists
     const propsNode = getComponentPropsNode(request, node);
     if (propsNode === undefined) {

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
@@ -3,7 +3,7 @@ import { IMutation, ITextInsertMutation } from "automutate";
 import { printNewLine } from "../../../../../shared/printing";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
-import { isVisitableComponentNode, ReactComponentNode } from "../reactFiltering/isVisitableComponentClass";
+import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 import { createInterfaceFromPropTypes } from "./propTypes/createInterfaceFromPropTypes";
 import { getPropTypesValue } from "./propTypes/getPropTypesValue";
@@ -12,7 +12,7 @@ import { getPropTypesValue } from "./propTypes/getPropTypesValue";
  * Creates an initial props type for a component from its PropTypes declaration.
  */
 export const fixReactPropsFromPropTypes: FileMutator = (request: FileMutationsRequest): ReadonlyArray<IMutation> => {
-    return collectMutationsFromNodes(request, isVisitableComponentNode, visitClassDeclaration);
+    return collectMutationsFromNodes(request, isReactComponentNode, visitClassDeclaration);
 };
 
 const visitClassDeclaration = (node: ReactComponentNode, request: FileMutationsRequest): ITextInsertMutation | undefined => {

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/createInterfaceFromPropTypes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/createInterfaceFromPropTypes.ts
@@ -1,8 +1,10 @@
 import * as ts from "typescript";
 
+import { ReactComponentNode } from "../../reactFiltering/isReactComponentNode";
+
 import { createPropTypesProperty } from "./propTypesProperties";
 
-export const createInterfaceFromPropTypes = (node: ts.ClassDeclaration, propTypes: ts.ObjectLiteralExpression) => {
+export const createInterfaceFromPropTypes = (node: ReactComponentNode, propTypes: ts.ObjectLiteralExpression) => {
     const members: ts.TypeElement[] = [];
 
     for (const rawProperty of propTypes.properties) {
@@ -12,13 +14,23 @@ export const createInterfaceFromPropTypes = (node: ts.ClassDeclaration, propType
         }
     }
 
+    const apparentName = getApparentNameOfComponent(node);
+
     return ts.createInterfaceDeclaration(
         undefined /* decorators */,
         undefined /* modifiers */,
         // Todo: allow preference for name templating
-        node.name === undefined ? "AnonymousClassProps" : `${node.name.text}Props`,
+        apparentName === undefined ? "AnonymousClassProps" : `${apparentName}Props`,
         undefined /* typeParameters */,
         undefined /* heritageClauses */,
         members,
     );
+};
+
+const getApparentNameOfComponent = (node: ReactComponentNode): string | undefined => {
+    if (node.name !== undefined) {
+        return node.name.text;
+    }
+
+    return undefined;
 };

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
@@ -2,12 +2,17 @@ import * as ts from "typescript";
 
 import { getClassExtendsType } from "../../../../../shared/nodes";
 
-/**
- * @remarks Eventually, this should also allow functional components.
- */
-export type ReactComponentNode = ts.ClassDeclaration;
+export type ReactComponentNode = ReactClassComponentNode | ReactFunctionalComponentNode;
 
-export const isVisitableComponentNode = (node: ts.Node): node is ReactComponentNode => {
+export type ReactClassComponentNode = ts.ClassDeclaration | ts.ClassExpression;
+
+export type ReactFunctionalComponentNode = ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression;
+
+export const isReactComponentNode = (node: ts.Node): node is ReactComponentNode => {
+    if (ts.isArrowFunction(node) || ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) {
+        return true;
+    }
+
     if (!ts.isClassDeclaration(node)) {
         return false;
     }

--- a/src/shared/nodes.ts
+++ b/src/shared/nodes.ts
@@ -84,7 +84,7 @@ export const getVariableInitializerForExpression = (
     return valueDeclaration.initializer;
 };
 
-export const getClassExtendsType = (node: ts.ClassDeclaration): ts.ExpressionWithTypeArguments | undefined => {
+export const getClassExtendsType = (node: ts.ClassDeclaration | ts.ClassExpression): ts.ExpressionWithTypeArguments | undefined => {
     const { heritageClauses } = node;
     if (heritageClauses === undefined) {
         return undefined;

--- a/test/cases/unit/functional components/arrow functions/incompleteTypes/actual.tsx
+++ b/test/cases/unit/functional components/arrow functions/incompleteTypes/actual.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    const UsesExternalProps = (props: MyProps) => {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+interface DeclaresPropsWithPropTypesProps {
+    declaredString?: string;
+}
+
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/arrow functions/incompleteTypes/expected.tsx
+++ b/test/cases/unit/functional components/arrow functions/incompleteTypes/expected.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    const UsesExternalProps = (props: MyProps) => {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+interface DeclaresPropsWithPropTypesProps {
+    declaredString?: string;
+}
+
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/arrow functions/incompleteTypes/tsconfig.json
+++ b/test/cases/unit/functional components/arrow functions/incompleteTypes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "jsx": "react",
+        "strictNullChecks": true
+    },
+    "files": ["actual.tsx"]
+}

--- a/test/cases/unit/functional components/arrow functions/incompleteTypes/typestat.json
+++ b/test/cases/unit/functional components/arrow functions/incompleteTypes/typestat.json
@@ -1,0 +1,8 @@
+{
+    "fixes": {
+        "incompleteTypes": true
+    },
+    "types": {
+        "strictNullChecks": true
+    }
+}

--- a/test/cases/unit/functional components/arrow functions/original.tsx
+++ b/test/cases/unit/functional components/arrow functions/original.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    const UsesExternalProps = (props: MyProps) => {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/function declarations/incompleteTypes/actual.tsx
+++ b/test/cases/unit/functional components/function declarations/incompleteTypes/actual.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    function UsesExternalProps(props: MyProps) {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+interface DeclaresPropsWithPropTypesProps {
+    declaredString?: string;
+}
+
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/function declarations/incompleteTypes/expected.tsx
+++ b/test/cases/unit/functional components/function declarations/incompleteTypes/expected.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    function UsesExternalProps(props: MyProps) {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+interface DeclaresPropsWithPropTypesProps {
+    declaredString?: string;
+}
+
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/function declarations/incompleteTypes/tsconfig.json
+++ b/test/cases/unit/functional components/function declarations/incompleteTypes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "jsx": "react",
+        "strictNullChecks": true
+    },
+    "files": ["actual.tsx"]
+}

--- a/test/cases/unit/functional components/function declarations/incompleteTypes/typestat.json
+++ b/test/cases/unit/functional components/function declarations/incompleteTypes/typestat.json
@@ -1,0 +1,8 @@
+{
+    "fixes": {
+        "incompleteTypes": true
+    },
+    "types": {
+        "strictNullChecks": true
+    }
+}

--- a/test/cases/unit/functional components/function declarations/original.tsx
+++ b/test/cases/unit/functional components/function declarations/original.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    function UsesExternalProps(props: MyProps) {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/function expressions/incompleteTypes/actual.tsx
+++ b/test/cases/unit/functional components/function expressions/incompleteTypes/actual.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    const UsesExternalProps = function (props: MyProps) {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+interface DeclaresPropsWithPropTypesProps {
+    declaredString?: string;
+}
+
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/function expressions/incompleteTypes/expected.tsx
+++ b/test/cases/unit/functional components/function expressions/incompleteTypes/expected.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    const UsesExternalProps = function (props: MyProps) {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+interface DeclaresPropsWithPropTypesProps {
+    declaredString?: string;
+}
+
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();

--- a/test/cases/unit/functional components/function expressions/incompleteTypes/tsconfig.json
+++ b/test/cases/unit/functional components/function expressions/incompleteTypes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "jsx": "react",
+        "strictNullChecks": true
+    },
+    "files": ["actual.tsx"]
+}

--- a/test/cases/unit/functional components/function expressions/incompleteTypes/typestat.json
+++ b/test/cases/unit/functional components/function expressions/incompleteTypes/typestat.json
@@ -1,0 +1,8 @@
+{
+    "fixes": {
+        "incompleteTypes": true
+    },
+    "types": {
+        "strictNullChecks": true
+    }
+}

--- a/test/cases/unit/functional components/function expressions/original.tsx
+++ b/test/cases/unit/functional components/function expressions/original.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+(function() {
+    interface MyProps {
+        unused: boolean;
+    }
+
+    const UsesExternalProps = function (props: MyProps) {
+        return "";
+    }
+
+    const jsx = <UsesExternalProps givenBoolean />;
+
+    function DeclaresPropsWithPropTypes(props) {}
+
+    DeclaresPropsWithPropTypes.propTypes = {
+        declaredString: PropTypes.string,
+    };
+})();


### PR DESCRIPTION
Most of the changes are in test cases and typings. Getting the name or prop types declaration of a node now means checking which form it is & acting appropriately.

Fixes #131.