### PR TITLE
Skipped implicit generic interfaces for no missing types

### DIFF
--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/index.ts
@@ -1,6 +1,7 @@
 import { combineMutations, IMutation } from "automutate";
 import * as ts from "typescript";
 
+import { isNotUndefined } from "../../../../shared/arrays";
 import { getBaseClassDeclaration, getClassExtendsExpression } from "../../../../shared/nodeExtensions";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
@@ -27,7 +28,9 @@ const visitClassLike = (node: ts.ClassLikeDeclaration, request: FileMutationsReq
 
     // If that class declares any templated types, check the node's types assigned as them
     const missingTemplateTypes = findMissingTemplateTypes(request, node, baseClass);
-    if (missingTemplateTypes.length === 0) {
+
+    // We can skip performing any mutation if none of the parameter types had missing types
+    if (missingTemplateTypes.length === 0 || !missingTemplateTypes.some(isNotUndefined)) {
         return undefined;
     }
 

--- a/test/cases/unit/missing generic property declarations/incompleteTypes/expected.ts
+++ b/test/cases/unit/missing generic property declarations/incompleteTypes/expected.ts
@@ -3,6 +3,10 @@
         first: TFirst;
     }
 
+    class ExtendedWithNothingAdded extends OneTypeParameter {
+        ignored = 0;
+    }
+
 type ExtendingWithAddedFirst = {
 added?: boolean;
 };
@@ -16,46 +20,34 @@ added?: boolean;
         }
     }
 
-type ExtendingWithExistingFirst = {
-added?: boolean;
-};
+    // class ExtendingWithExisting extends OneTypeParameter {
+    //     constructor() {
+    //         super();
+    //         this.first = {
+    //             existing: true,
+    //         };
+    //     }
+    // }
 
-    class ExtendingWithExisting extends OneTypeParameter<ExtendingWithExistingFirst> {
-        constructor() {
-            super();
-            this.first = {
-                existing: true,
-            };
-        }
-    }
+    // class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
+    //     second: TSecond;
+    // }
 
-    class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
-        second: TSecond;
-    }
+    // class ExtendingWithDefault extends SkippedTypeParameter<{}> {
+    //     constructor() {
+    //         super();
+    //         this.second = {
+    //             added: true,
+    //         };
+    //     }
+    // }
 
-type ExtendingWithDefaultSecond = {
-added?: boolean;
-};
-
-    class ExtendingWithDefault extends SkippedTypeParameter<{}, ExtendingWithDefaultSecond> {
-        constructor() {
-            super();
-            this.second = {
-                added: true,
-            };
-        }
-    }
-
-type ExtendingWithSkippedSecond = {
-added?: boolean;
-};
-
-    class ExtendingWithSkipped extends SkippedTypeParameter<{}, ExtendingWithSkippedSecond> {
-        constructor() {
-            super();
-            this.second = {
-                existing: true,
-            };
-        }
-    }
+    // class ExtendingWithSkipped extends SkippedTypeParameter {
+    //     constructor() {
+    //         super();
+    //         this.second = {
+    //             existing: true,
+    //         };
+    //     }
+    // }
 })();

--- a/test/cases/unit/missing generic property declarations/incompleteTypes/expected.ts
+++ b/test/cases/unit/missing generic property declarations/incompleteTypes/expected.ts
@@ -20,34 +20,46 @@ added?: boolean;
         }
     }
 
-    // class ExtendingWithExisting extends OneTypeParameter {
-    //     constructor() {
-    //         super();
-    //         this.first = {
-    //             existing: true,
-    //         };
-    //     }
-    // }
+type ExtendingWithExistingFirst = {
+added?: boolean;
+};
 
-    // class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
-    //     second: TSecond;
-    // }
+    class ExtendingWithExisting extends OneTypeParameter<ExtendingWithExistingFirst> {
+        constructor() {
+            super();
+            this.first = {
+                existing: true,
+            };
+        }
+    }
 
-    // class ExtendingWithDefault extends SkippedTypeParameter<{}> {
-    //     constructor() {
-    //         super();
-    //         this.second = {
-    //             added: true,
-    //         };
-    //     }
-    // }
+    class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
+        second: TSecond;
+    }
 
-    // class ExtendingWithSkipped extends SkippedTypeParameter {
-    //     constructor() {
-    //         super();
-    //         this.second = {
-    //             existing: true,
-    //         };
-    //     }
-    // }
+type ExtendingWithDefaultSecond = {
+added?: boolean;
+};
+
+    class ExtendingWithDefault extends SkippedTypeParameter<{}, ExtendingWithDefaultSecond> {
+        constructor() {
+            super();
+            this.second = {
+                added: true,
+            };
+        }
+    }
+
+type ExtendingWithSkippedSecond = {
+added?: boolean;
+};
+
+    class ExtendingWithSkipped extends SkippedTypeParameter<{}, ExtendingWithSkippedSecond> {
+        constructor() {
+            super();
+            this.second = {
+                existing: true,
+            };
+        }
+    }
 })();

--- a/test/cases/unit/missing generic property declarations/original.ts
+++ b/test/cases/unit/missing generic property declarations/original.ts
@@ -16,34 +16,34 @@
         }
     }
 
-    // class ExtendingWithExisting extends OneTypeParameter {
-    //     constructor() {
-    //         super();
-    //         this.first = {
-    //             existing: true,
-    //         };
-    //     }
-    // }
+    class ExtendingWithExisting extends OneTypeParameter {
+        constructor() {
+            super();
+            this.first = {
+                existing: true,
+            };
+        }
+    }
 
-    // class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
-    //     second: TSecond;
-    // }
+    class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
+        second: TSecond;
+    }
 
-    // class ExtendingWithDefault extends SkippedTypeParameter<{}> {
-    //     constructor() {
-    //         super();
-    //         this.second = {
-    //             added: true,
-    //         };
-    //     }
-    // }
+    class ExtendingWithDefault extends SkippedTypeParameter<{}> {
+        constructor() {
+            super();
+            this.second = {
+                added: true,
+            };
+        }
+    }
 
-    // class ExtendingWithSkipped extends SkippedTypeParameter {
-    //     constructor() {
-    //         super();
-    //         this.second = {
-    //             existing: true,
-    //         };
-    //     }
-    // }
+    class ExtendingWithSkipped extends SkippedTypeParameter {
+        constructor() {
+            super();
+            this.second = {
+                existing: true,
+            };
+        }
+    }
 })();

--- a/test/cases/unit/missing generic property declarations/original.ts
+++ b/test/cases/unit/missing generic property declarations/original.ts
@@ -3,6 +3,10 @@
         first: TFirst;
     }
 
+    class ExtendedWithNothingAdded extends OneTypeParameter {
+        ignored = 0;
+    }
+
     class ExtendingWithAdded extends OneTypeParameter {
         constructor() {
             super();
@@ -12,34 +16,34 @@
         }
     }
 
-    class ExtendingWithExisting extends OneTypeParameter {
-        constructor() {
-            super();
-            this.first = {
-                existing: true,
-            };
-        }
-    }
+    // class ExtendingWithExisting extends OneTypeParameter {
+    //     constructor() {
+    //         super();
+    //         this.first = {
+    //             existing: true,
+    //         };
+    //     }
+    // }
 
-    class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
-        second: TSecond;
-    }
+    // class SkippedTypeParameter<TFirst, TSecond = { existing: true }> {
+    //     second: TSecond;
+    // }
 
-    class ExtendingWithDefault extends SkippedTypeParameter<{}> {
-        constructor() {
-            super();
-            this.second = {
-                added: true,
-            };
-        }
-    }
+    // class ExtendingWithDefault extends SkippedTypeParameter<{}> {
+    //     constructor() {
+    //         super();
+    //         this.second = {
+    //             added: true,
+    //         };
+    //     }
+    // }
 
-    class ExtendingWithSkipped extends SkippedTypeParameter {
-        constructor() {
-            super();
-            this.second = {
-                existing: true,
-            };
-        }
-    }
+    // class ExtendingWithSkipped extends SkippedTypeParameter {
+    //     constructor() {
+    //         super();
+    //         this.second = {
+    //             existing: true,
+    //         };
+    //     }
+    // }
 })();


### PR DESCRIPTION
We can skip performing any mutation if none of the parameter types discovered in fixIncompleteImplicitGenerics had missing types