### PR TITLE
Simplified core mutations provider resetting

### DIFF
--- a/src/shared/NameGenerator.test.ts
+++ b/src/shared/NameGenerator.test.ts
@@ -1,0 +1,42 @@
+import { NameGenerator } from "./NameGenerator";
+
+describe("NameGenerator", () => {
+    it("creates a basic name when the base portion hasn't been requested yet", () => {
+        // Arrange
+        const sourceFileName = "File";
+        const nameGenerator = new NameGenerator(sourceFileName);
+
+        // Act
+        const name = nameGenerator.generateName("Base");
+
+        // Assert
+        expect(name).toEqual("FileBase");
+    });
+
+    it("creates a 1-suffixed name when the base portion has been requested once", () => {
+        // Arrange
+        const sourceFileName = "File";
+        const nameGenerator = new NameGenerator(sourceFileName);
+        nameGenerator.generateName("Base");
+
+        // Act
+        const name = nameGenerator.generateName("Base");
+
+        // Assert
+        expect(name).toEqual("FileBase2");
+    });
+
+    it("creates 2-suffixed name when the base portion has been requested twice", () => {
+        // Arrange
+        const sourceFileName = "File";
+        const nameGenerator = new NameGenerator(sourceFileName);
+        nameGenerator.generateName("Base");
+        nameGenerator.generateName("Base");
+
+        // Act
+        const name = nameGenerator.generateName("Base");
+
+        // Assert
+        expect(name).toEqual("FileBase3");
+    });
+});

--- a/src/shared/NameGenerator.ts
+++ b/src/shared/NameGenerator.ts
@@ -1,3 +1,6 @@
+/**
+ * Generates new names that are unique per file.
+ */
 export class NameGenerator {
     private readonly countsPerBase = new Map<string, number>();
 


### PR DESCRIPTION
Moves clearing of the services cache to when lastFileIndex is set to 0. I don't know why this would make things work better but it seems that duplicate mutations no longer get applied with this. Spooky.

Fixes #259. Or maybe not. Who knows?