### PR TITLE
Stopped collecting assigned function types from declared function types

### DIFF
--- a/src/mutations/collecting/flags.ts
+++ b/src/mutations/collecting/flags.ts
@@ -18,7 +18,7 @@ export const findMissingFlags = (
     declaredType: ts.Type,
     assignedFlags: ReadonlySet<ts.TypeFlags>,
     declaredFlags: ReadonlySet<ts.TypeFlags>,
-) => {
+): Set<ts.TypeFlags> => {
     // If the type is declared to allow `any`, it can't be missing anything
     if (isTypeFlagSetRecursively(declaredType, ts.TypeFlags.Any)) {
         return new Set();

--- a/test/cases/types/aliases/assertions/expected.ts
+++ b/test/cases/types/aliases/assertions/expected.ts
@@ -22,4 +22,10 @@
             return "";
         };
     }
+
+    function multipleFunctionTypes(): () => void {
+        return Math.random() > 0.5
+            ? ((() => {}) as (() => void))
+            : ((() => {}) as (() => undefined))
+    }
 })();

--- a/test/cases/types/aliases/original.ts
+++ b/test/cases/types/aliases/original.ts
@@ -22,4 +22,10 @@
             return "";
         };
     }
+
+    function multipleFunctionTypes(): () => void {
+        return Math.random() > 0.5
+            ? ((() => {}) as (() => void))
+            : ((() => {}) as (() => undefined))
+    }
 })();

--- a/test/cases/types/aliases/types/expected.ts
+++ b/test/cases/types/aliases/types/expected.ts
@@ -22,4 +22,10 @@
             return "";
         };
     }
+
+    function multipleFunctionTypes(): () => void {
+        return Math.random() > 0.5
+            ? ((() => {}) as (() => void))
+            : ((() => {}) as (() => undefined))
+    }
 })();


### PR DESCRIPTION
Ignores assigned function types when the declared type(s) include function(s).

Fixes #269.