### PR TITLE
Used findReferencesAsNodes instead of findReferences directly

### DIFF
--- a/src/shared/FileInfoCache.ts
+++ b/src/shared/FileInfoCache.ts
@@ -3,11 +3,10 @@ import * as ts from "typescript";
 
 import { LanguageServices } from "../services/language";
 
-import { findRelevantNodeReferences, findRelevantNodeReferencesAsNodes } from "./references";
+import { findRelevantNodeReferencesAsNodes } from "./references";
 
 export class FileInfoCache {
-    private readonly nodeReferences = new Map<ts.Node, ReadonlyArray<ts.ReferenceEntry> | undefined>();
-    private readonly nodeReferencesAsNodes = new Map<ts.Node, ReadonlyArray<ts.Node> | undefined>();
+    private readonly nodeReferences = new Map<ts.Node, ReadonlyArray<ts.Node> | undefined>();
     private variableUsage: ReadonlyMap<ts.Identifier, tsutils.VariableInfo> | undefined;
 
     public constructor(
@@ -17,26 +16,14 @@ export class FileInfoCache {
     ) {}
 
     /**
-     * @returns All raw reference entries from a node.
-     */
-    public getNodeReferences(node: ts.Node): ReadonlyArray<ts.ReferenceEntry> | undefined {
-        let references = this.nodeReferences.get(node);
-
-        if (references === undefined) {
-            references = findRelevantNodeReferences(this.filteredNodes, this.services, this.sourceFile, node);
-        }
-
-        return references;
-    }
-
-    /**
      * @returns All corresponding nodes for the reference entries for a node.
      */
     public getNodeReferencesAsNodes(node: ts.Node): ReadonlyArray<ts.Node> | undefined {
-        let references = this.nodeReferencesAsNodes.get(node);
+        let references = this.nodeReferences.get(node);
 
         if (references === undefined) {
             references = findRelevantNodeReferencesAsNodes(this.filteredNodes, this.services, this.sourceFile, node);
+            this.nodeReferences.set(node, references);
         }
 
         return references;

--- a/src/shared/references.ts
+++ b/src/shared/references.ts
@@ -4,33 +4,18 @@ import { LanguageServices } from "../services/language";
 
 import { findNodeByStartingPosition } from "./nodes";
 
-export const findRelevantNodeReferences = (
-    filteredNodes: ReadonlySet<ts.Node>,
-    services: LanguageServices,
-    sourceFile: ts.SourceFile,
-    node: ts.Node,
-): ts.ReferenceEntry[] | undefined => {
-    // Find all locations the containing method is referenced
-    const referencedSymbols = services.languageService.findReferences(sourceFile.fileName, node.getStart(sourceFile));
-    if (referencedSymbols === undefined) {
-        return undefined;
-    }
-
-    const references = new Set<ts.ReferenceEntry>();
-
-    // For each reference within the referencing symbols, add it if it's not the child of a filtered node
-    for (const referenceSymbol of referencedSymbols) {
-        for (const reference of referenceSymbol.references) {
-            if (!referenceIsFilteredOut(filteredNodes, sourceFile, reference)) {
-                references.add(reference);
-            }
+export const isNodeFilteredOut = (filteredNodes: ReadonlySet<ts.Node>, node: ts.Node | undefined): boolean => {
+    while (node !== undefined) {
+        if (filteredNodes.has(node)) {
+            return true;
         }
+
+        node = node.parent;
     }
 
-    return Array.from(references);
+    return false;
 };
 
-// TODO: file issue to clean up existing uses of findRelevantNodeReferences that could just use this
 export const findRelevantNodeReferencesAsNodes = (
     filteredNodes: ReadonlySet<ts.Node>,
     services: LanguageServices,
@@ -51,9 +36,9 @@ export const findRelevantNodeReferencesAsNodes = (
             continue;
         }
 
-        // Find the referencing node from its place in the source file, unless it's roughly the original node
-        const referencingNode = findNodeByStartingPosition(sourceFile, reference.textSpan.start);
-        if (referencingNode === identifyingNode || referencingNode === identifyingNode) {
+        // Find the referencing node from its place in that source file, unless it's the original node
+        const referencingNode = findNodeByStartingPosition(referencingSourceFile, reference.textSpan.start);
+        if (referencingNode === identifyingNode) {
             continue;
         }
 
@@ -67,14 +52,28 @@ const referenceIsFilteredOut = (filteredNodes: ReadonlySet<ts.Node>, sourceFile:
     return isNodeFilteredOut(filteredNodes, findNodeByStartingPosition(sourceFile, reference.textSpan.start));
 };
 
-export const isNodeFilteredOut = (filteredNodes: ReadonlySet<ts.Node>, node: ts.Node | undefined): boolean => {
-    while (node !== undefined) {
-        if (filteredNodes.has(node)) {
-            return true;
-        }
-
-        node = node.parent;
+const findRelevantNodeReferences = (
+    filteredNodes: ReadonlySet<ts.Node>,
+    services: LanguageServices,
+    sourceFile: ts.SourceFile,
+    node: ts.Node,
+): ts.ReferenceEntry[] | undefined => {
+    // Find all locations the node is referenced
+    const referencedSymbols = services.languageService.findReferences(sourceFile.fileName, node.getStart(sourceFile));
+    if (referencedSymbols === undefined) {
+        return undefined;
     }
 
-    return false;
+    const references = new Set<ts.ReferenceEntry>();
+
+    // For each reference within the referencing symbols, add it if it's not the child of a filtered node
+    for (const referenceSymbol of referencedSymbols) {
+        for (const reference of referenceSymbol.references) {
+            if (!referenceIsFilteredOut(filteredNodes, sourceFile, reference)) {
+                references.add(reference);
+            }
+        }
+    }
+
+    return Array.from(references);
 };


### PR DESCRIPTION
There were previously two common ways in TypeStat fixers to find all references to a node: finding all the direct ts.ReferenceEntry instances, or a helpful wrapper around that to convert them to nodes. This PR switches everyone to using the helpful wrapper because there's no reason to want the direct reference entry otherwise.

Also seems to fix bugs around requesting source nodes from outside a particular position in a source file by using the referencing source file in lookup code here, rather than the original node's source file.