### PR TITLE
Fixed miscellaneous bugs around React component signatures

### DIFF
--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
@@ -28,7 +28,8 @@ const getClassComponentPropsNode = (request: FileMutationsRequest, node: ReactCl
         return undefined;
     }
 
-    const declaration = propsNodeSymbol.declarations.length === 0 ? undefined : propsNodeSymbol.declarations[0];
+    const symbolDeclarations = propsNodeSymbol.getDeclarations();
+    const declaration = symbolDeclarations === undefined || symbolDeclarations.length === 0 ? undefined : symbolDeclarations[0];
 
     return declaration !== undefined && isReactComponentPropsNode(declaration) ? declaration : undefined;
 };

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
@@ -1,6 +1,7 @@
 import { combineMutations, IMutation, ITextInsertMutation } from "automutate";
 import * as ts from "typescript";
 
+import { getClassExtendsType } from "../../../../../shared/nodes";
 import { printNewLine } from "../../../../../shared/printing/newlines";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
@@ -9,7 +10,6 @@ import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isRe
 import { createInterfaceUsageMutation } from "./annotation/createInterfaceUsageMutation";
 import { createInterfaceFromPropTypes } from "./propTypes/createInterfaceFromPropTypes";
 import { getPropTypesValue } from "./propTypes/getPropTypesValue";
-import { getClassExtendsType } from "../../../../../shared/nodes";
 
 /**
  * Creates an initial props type for a component from its PropTypes declaration.

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
@@ -9,6 +9,7 @@ import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isRe
 import { createInterfaceUsageMutation } from "./annotation/createInterfaceUsageMutation";
 import { createInterfaceFromPropTypes } from "./propTypes/createInterfaceFromPropTypes";
 import { getPropTypesValue } from "./propTypes/getPropTypesValue";
+import { getClassExtendsType } from "../../../../../shared/nodes";
 
 /**
  * Creates an initial props type for a component from its PropTypes declaration.
@@ -18,8 +19,17 @@ export const fixReactPropsFromPropTypes: FileMutator = (request: FileMutationsRe
 };
 
 const visitReactComponentNode = (node: ReactComponentNode, request: FileMutationsRequest): IMutation | undefined => {
+    // If the node is a class declaration, don't bother with prop types if it already declares a React.Component template
+    if (ts.isClassDeclaration(node)) {
+        const extendsType = getClassExtendsType(node);
+
+        if (extendsType !== undefined && extendsType.typeArguments !== undefined && extendsType.typeArguments.length > 0) {
+            return undefined;
+        }
+    }
+
     // Try to find a static `propTypes` member to indicate the interface
-    // If it doesn't exist, we can't infer anything about the class here, so we bail out
+    // If it doesn't exist, we can't infer anything about the component here, so we bail out
     const propTypes = getPropTypesValue(node);
     if (propTypes === undefined) {
         return undefined;
@@ -28,7 +38,7 @@ const visitReactComponentNode = (node: ReactComponentNode, request: FileMutation
     // Since we did find the propTypes object, we can generate an interface from its members
     const { interfaceName, interfaceNode } = createInterfaceFromPropTypes(request, node, propTypes);
 
-    // That interface will be injected with blank lines around it just before the class
+    // That interface will be injected with blank lines around it just before the component
     const mutations: IMutation[] = [createInterfaceCreationMutation(request, node, interfaceNode)];
 
     // We'll also annotate the component with a type declaration to use the new prop type

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
@@ -8,18 +8,23 @@ export type ReactClassComponentNode = ts.ClassDeclaration | ts.ClassExpression;
 
 export type ReactFunctionalComponentNode = ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression;
 
+/**
+ * @returns Whether the node is able to be a React component node.
+ */
 export const isReactComponentNode = (node: ts.Node): node is ReactComponentNode => {
+    // Functions can generally be React components if they have 0 or 1 parameters
     if (ts.isArrowFunction(node) || ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) {
-        return true;
+        return node.parameters.length <= 1;
     }
 
+    // Otherwise, we only look at class declarations
     if (!ts.isClassDeclaration(node)) {
         return false;
     }
 
     const extendsType = getClassExtendsType(node);
 
-    return extendsType === undefined ? false : extensionExpressionIsReactComponent(extendsType);
+    return extendsType !== undefined && extensionExpressionIsReactComponent(extendsType);
 };
 
 const extensionExpressionIsReactComponent = (node: ts.ExpressionWithTypeArguments): boolean => {


### PR DESCRIPTION
When the props node doesn't have any declarations, getComponentPropsNode shouldn't bother trying to look through them.

I haven't filed bugs about this bug I remember there being crashes associated...