### PR TITLE
Removed CLI flags also included in config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,6 @@ For instructions on the types of changes you can run with Typestat, see:
 
 Path to a TypeStat configuration file, if you'd like a custom path.
 
-```shell
-typestat --config typestat.custom.json
-```
-
 #### `include`
 
 Glob patterns of file names to include.
@@ -91,20 +87,6 @@ typestat ./src/**/*.ts
 }
 ```
 
-#### `-p`/`--project`
-
-Path to a TypeScript project file, if you'd like a path other than `./tsconfig.json`.
-
-```shell
-typestat --project tsconfig.strict.json
-```
-
-```json
-{
-    "project": "tsconfig.strict.json"
-}
-```
-
 If a relative project file path is provided, its absolute path will be resolved from `--packageDirectory`.
 
 ### Usage
@@ -112,25 +94,25 @@ If a relative project file path is provided, its absolute path will be resolved 
 More advanced flags can be provided for:
 
 * [Files](./docs/Files.md)
-  * `--fileAbove`/`files.above`
-  * `--fileBelow`/`files.below`
-  * `--fileConvertFileExtensions`/`files.convertFileExtensions`
+  * `files.above`
+  * `files.below`
+  * `files.convertFileExtensions`
 * [Filters](./docs/Filters.md)
-  * `--filter`/`filter`
+  * `filter`
 * [Fixes](./docs/Fixes.md):
-  * `--fixIncompleteTypes`/`fixes.incompleteTypes`
-  * `--fixMissingProperties`/`fixes.missingProperties`
-  * `--fixNoImplicitAny`/`fixes.noImplicitAny`
-  * `--fixStrictNonNullAssertions`/`fixes.strictNonNullAssertions`
+  * `fixes.incompleteTypes`
+  * `fixes.missingProperties`
+  * `fixes.noImplicitAny`
+  * `fixes.strictNonNullAssertions`
 * [Package](./docs/Package.md):
-  * `--packageDirectory`/`package.directory`
-  * `--packageFile`/`package.file`
-  * `--packageMissingTypes`/`package.missingTypes`
+  * `package.directory`
+  * `package.file`
+  * `package.missingTypes`
 * [Types](./docs/Types.md):
-  * `--typeAlias`/`types.aliases`
-  * `--typeMatching`/`types.matching`
-  * `--typeOnlyPrimitives`/`types.onlyPrimitives`
-  * `--typeStrictNullChecks`/`types.strictNullChecks`
+  * `types.aliases`
+  * `types.matching`
+  * `types.onlyPrimitives`
+  * `types.strictNullChecks`
 
 ## Node
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -21,13 +21,13 @@ When the `typestat` command is entered into the CLI, roughly the following happe
 
 There are three mutation providers that are run in order by [`createTypeStatMutationsProvider`](src/runtime/createTypeStatMutationsProvider.ts):
 
-1. **Require renames**: changes to `import` and `require` statements from `--fileRenameExtensions`
+1. **Require renames**: changes to `import` and `require` statements from `files.renameExtensions`
 2. **Core mutations**: changes to type annotations in provided files
-3. **Files modified**: adds annotations to the top (`--fileAbove`) and/or bottom (`--fileBelow`) of files if enabled
+3. **Files modified**: adds annotations to the top (`files.above`) and/or bottom (`files.below`) of mutated files if enabled
 
 #### Require Renames
 
-If any `require` to a file including the extension is stored as a variable, and `--fileRenameExtensions` is enabled,
+If any `require` to a file including the extension is stored as a variable, and `files.renameExtensions` is enabled,
 that variable will be given a type equivalent to the extensionless equivalent.
 This is done as a separate mutation provider before the core mutations to ensure these mutations are applied before core mutations.
 
@@ -132,15 +132,3 @@ Now it does.
 Maybe this should be converted?
 
 See [#20](https://github.com/JoshuaKGoldberg/TypeStat/issues/20).
-
-## Why Not [TSLint](https://github.com/palantir/tslint)?
-
-Or: why isn't this implemented as a set of [TSLint](https://github.com/palantir/tslint) rules?
-
-Great question!
-TSLint rules, even with [type checking](https://palantir.github.io/tslint/usage/type-checking), don't have access to the full [TypeScript language service](https://github.com/Microsoft/TypeScript/wiki/Using-the-Language-Service-API).
-This is by design for performance and reliability reasons.
-TypeStat needs that service.
-
-TSLint also has a [relatively unstable `--fix`](https://github.com/palantir/tslint/issues/2556) that can't handle multiple rounds of mutations.
-TypeStat is built on [Automutate](https://github.com/automutate/automutate), which is more stable and allows multiple rounds.

--- a/docs/Custom Mutators.md
+++ b/docs/Custom Mutators.md
@@ -7,10 +7,6 @@ Built-in mutators will be disabled if you provide any custom ones.
 
 Use the `-m`/`--mutators` CLI flag and/or `mutators` configuration setting to add `require`-style paths of mutators to add.
 
-```shell
-typestat --mutators my-mutator-module
-```
-
 ```json
 {
     "mutators": [

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -70,5 +70,5 @@ Run it with `node --inspect` then visit `chrome://inspect` to use the browser de
 For example:
 
 ```shell
-node --inspect typestat src/**/*.test.ts --config typestat.json --project src/tsconfig.json --fixIncompleteTypes
+node --inspect typestat --config typestat.json
 ```

--- a/docs/Files.md
+++ b/docs/Files.md
@@ -12,11 +12,7 @@ An optional set of CLI flags and/or configuration object fields containing file-
 }
 ```
 
-## `--fileAbove`/`above`
-
-```shell
-typestat --fileAbove "/* Above file */"
-```
+## `above`
 
 ```json
 {
@@ -32,11 +28,7 @@ If provided, any modified file will have the text inserted as a new first line.
 The default is `""`, for no action to take.
 If a value is provided on the CLI, it will override a configuration file value (including `""`).
 
-## `--fileBelow`/`below`
-
-```shell
-typestat --fileBelow "/* Below file */"
-```
+## `below`
 
 ```json
 {
@@ -52,11 +44,7 @@ If provided, any modified file will have the text inserted as a new last line.
 The default is `""`, for no action to take.
 If a value is provided on the CLI, it will override a configuration file value (including `""`).
 
-## `--fileRenameExtensions`/`renameExtensions`
-
-```shell
-typestat --fileRenameExtensions
-```
+## `renameExtensions`
 
 ```json
 {
@@ -77,10 +65,6 @@ This field has four potential allowed configurations:
 * `false` _(default)_: skip renaming file extensions
 * `true`: auto-detect whether a file should be `.ts` or `.tsx`
 
-    ```shell
-    typestat --fileRenameExtensions
-    ```
-
     ```json
     {
         "files": {
@@ -91,10 +75,6 @@ This field has four potential allowed configurations:
 
 * `"ts"`: always convert to `.ts`
 
-    ```shell
-    typestat --fileRenameExtensions ts
-    ```
-
     ```json
     {
         "files": {
@@ -104,10 +84,6 @@ This field has four potential allowed configurations:
     ```
 
 * `"tsx"`: always convert to `.tsx`
-
-    ```shell
-    typestat --fileRenameExtensions tsx
-    ```
 
     ```json
     {

--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -6,17 +6,13 @@ This is useful for...
 * ...when sections of source files can be safely excluded from type coverage
 * ...when you want to only touch up certain parts of source files
 
-TypeStat `--filter`/`filter` will _exclude_ any portions of source code that match them.
+`filter` will _exclude_ any portions of source code that match them.
 Sub-sections (child nodes) of those portions will not be visited.
 
 For example, it's common in some architectures for classes to have `dispose()` methods _(mirroring C#'s `IDisposable`)_ where private members are set to `null`.
 You can use filter to exclude these `null`s from type calculations.
 
-## `--filter`/`filter`
-
-```shell
-typestat --filter "MethodDeclaration[name.text=dispose]"
-```
+## `filter`
 
 ```json
 {

--- a/docs/Fixes.md
+++ b/docs/Fixes.md
@@ -19,25 +19,25 @@ These mutations are all purely additive and limited to the type system, meaning 
 
 ## Fixers
 
-### `--fixIncompleteTypes`/`incompleteTypes`
+### `incompleteTypes`
 
 Whether to augment type annotations that don't capture all values constructs can be set to.
 
 See [fixIncompleteTypes/README.md](../src/mutators/builtIn/fixIncompleteTypes/README.md).
 
-### `--fixMissingProperties`/`missingProperties`
+### `missingProperties`
 
 Whether to apply TypeScript's fixer for missing properties on classes.
 
 See [fixMisingProperties/README.md](../src/mutators/builtIn/fixMissingProperties/README.md).
 
-## `--fixNoImplicitAny`/`noImplicitAny`
+## `noImplicitAny`
 
 Whether to add type annotations to declarations that don't yet have them.
 
 See [fixNoImplicitAny/README.md](../src/mutators/builtIn/fixNoImplicitAny/README.md).
 
-## `--fixStrictNonNullAssertions`/`strictNonNullAssertions`
+## `strictNonNullAssertions`
 
 Whether to add missing non-null assertions.
 

--- a/docs/Package.md
+++ b/docs/Package.md
@@ -12,11 +12,7 @@ An optional set of CLI flags and/or configuration object fields containing packa
 }
 ```
 
-## `--packageDirectory`/`directory`
-
-```shell
-typestat --packageDirectory "../MyRepo"
-```
+## `directory`
 
 ```json
 {
@@ -29,11 +25,7 @@ typestat --packageDirectory "../MyRepo"
 Base directory to resolve paths from.
 All non-absolute paths within all settings except `-c`/`--config` will be resolved against this directory.
 
-## `--packageFile`/`file`
-
-```shell
-typestat --packageFile "./node/package.json"
-```
+## `file`
 
 ```json
 {
@@ -46,13 +38,9 @@ typestat --packageFile "./node/package.json"
 File path to a `package.json` to consider the project's package file.
 If not provided, defaults to `./package.json`.
 
-If `--packageFile` is relative, `--packageDirectory` will be used as a root path to resolve from.
+If `package.file` is relative, `package.directory` will be used as a root path to resolve from.
 
-## `--packageMissingTypes`/`missingTypes`
-
-```shell
-typestat --packageMissingTypes
-```
+## `missingTypes`
 
 ```json
 {
@@ -72,7 +60,7 @@ For example, if the following code exists in any file within the TypeScript proj
 import { array } from "lodash/array";
 ```
 
-TypeStat will attempt to install `@types/lodash` unless it's already any form of dependency in the `--packageFile`,
+TypeStat will attempt to install `@types/lodash` unless it's already any form of dependency in the `package.file`,
 
 ### Package Manager Configuration
 
@@ -80,10 +68,6 @@ This field has four potential allowed configurations:
 
 * `false` _(default)_: skip installing missing packages
 * `true`: auto-detect whether to use Yarn _(if a `yarn.lock` exists)_ or npm _(default)_
-
-    ```shell
-    typestat --packageMissingTypes
-    ```
 
     ```json
     {
@@ -95,10 +79,6 @@ This field has four potential allowed configurations:
 
 * `"npm"`: install using npm
 
-    ```shell
-    typestat --packageMissingTypes npm
-    ```
-
     ```json
     {
         "package": {
@@ -108,10 +88,6 @@ This field has four potential allowed configurations:
     ```
 
 * `"yarn"`: install using Yarn
-
-    ```shell
-    typestat --packageMissingTypes yarn
-    ```
 
     ```json
     {

--- a/docs/Types.md
+++ b/docs/Types.md
@@ -1,14 +1,10 @@
 # Types
 
-## `--typeAlias`/`aliases`
+## `aliases`
 
 Object mapping names of added types to strings to replace them with.
 
 For example, to replace `null` with `null /* TODO: check auto-generated types (thanks TypeStat!) */`:
-
-```shell
-typestat --typeAlias "null=null /* TODO: check added types (thanks TypeStat!) */"
-```
 
 ```json
 {
@@ -32,10 +28,6 @@ type TodoAutoAdded_null = null;
 type TodoAutoAdded_undefined = undefined;
 ```
 
-```shell
-typestat --typeAlias "null|undefined=TodoAutoAdded_{0}"
-```
-
 ```json
 {
     "types": {
@@ -48,10 +40,6 @@ typestat --typeAlias "null|undefined=TodoAutoAdded_{0}"
 
 You can also alias the `!` added for non-null assertions:
 
-```shell
-typestat --typeAlias undefined=TodoAutoAddedUndefined
-```
-
 ```json
 {
     "types": {
@@ -62,16 +50,12 @@ typestat --typeAlias undefined=TodoAutoAddedUndefined
 }
 ```
 
-## `--typeMatching`/`matching`
+## `matching`
 
 Regular expression matchers added types must match.
 If one or more of these are provided, any added type must match at least one of them.
 
 For example, either will only allow `null` or `undefined` as added types:
-
-```shell
-typestat --typeMatching "^null$" --typeMatching "^undefined$"
-```
 
 ```json
 {
@@ -83,14 +67,10 @@ typestat --typeMatching "^null$" --typeMatching "^undefined$"
 }
 ```
 
-## `--typeOnlyPrimitives`/`onlyPrimitives`
+## `onlyPrimitives`
 
 Whether to exclude type additions that contain complex object types, such as arrays and class instances.
-This is particularly useful for `--typeStrictNullChecks`, where the only relevant types are `null` and `undefined`.
-
-```shell
-typestat --typeOnlyPrimitives
-```
+This is particularly useful for `types.strictNullChecks`, where the only relevant types are `null` and `undefined`.
 
 ```json
 {
@@ -100,14 +80,10 @@ typestat --typeOnlyPrimitives
 }
 ```
 
-## `--typeStrictNullChecks`/`strictNullChecks`
+## `strictNullChecks`
 
 Whether to override the project's [`--strictNullChecks`](https://basarat.gitbooks.io/typescript/docs/options/strictNullChecks.html) setting.
 If true, TypeStat will set `strictNullChecks` to `true` regardless of your `tsconfig.json`.
-
-```shell
-typestat --typeStrictNullChecks
-```
 
 ```json
 {

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -22,11 +22,7 @@ Converting classes from JavaScript to TypeScript tends to be one of the more pai
 since classes in TypeScript need to have member properties declared.
 
 TypeScript provides a feature to infer and add those properties.
-Use `--fixMissingProperties`/`fixes.missingProperties` to apply those mutations across all files:
-
-```shell
-typestat --fixMissingProperties
-```
+Use `fixes.missingProperties` to apply those mutations across all files:
 
 ```json
 {
@@ -44,10 +40,6 @@ This will add `!`s as necessary to any locations that use nullable types unsafel
 ### Preferring ! Assertions
 
 For example, this configuration will add `!`s only to `*.test.ts` test files, such as with VS Code's [strict tests push](https://github.com/Microsoft/vscode/issues/65233):
-
-```shell
-typestat --fixStrictNonNullAssertions --typeStrictNullChecks ./src/**/*.test.ts
-```
 
 ```json
 {

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -28,26 +28,7 @@ export const runCli = async (rawArgv: ReadonlyArray<string>, runtime = createDef
     const command = new Command()
         .option("-c --config [config]", "path to a TypeStat config file")
         .option("-m --mutator [...mutator]", "require paths to any custom mutators to run")
-        .option("-p --project [project]", "path to a TypeScript project file")
-        .option("-V --version", "output the package version")
-        .option("--fileAbove", "comment to add above modified files")
-        .option("--fileBelow", "comment to add below modified files")
-        .option("--fileRenameExtensions", "whether to convert .js(x) files to .ts(x)")
-        .option("--filter [...filter]", "tsquery filters to exclude within files")
-        .option("--fixIncompleteTypes", "add missing types to existing, incomplete types")
-        .option("--fixMissingProperties", "add missing properties to classes from usage")
-        .option("--fixNoImplicitAny", "fix TypeScript's --noImplicitAny complaints")
-        .option(
-            "--fixStrictNonNullAssertions",
-            "add missing non-null assertions in nullable property accesses, function-like calls, and return types",
-        )
-        .option("--packageDirectory [packageDirectory]", "working directory (cwd) of the project")
-        .option("--packageFile [packageFile]", "package.json path to consider the project's package")
-        .option("--packageMissingTypes [packageMissingTypes]", "package manager to install missing types, or unspecified to auto-detect")
-        .option("--typeAlias [...typeAlias]", "add a key=value to replace added type names with")
-        .option("--typeMatching [...typeMatching]", "regular expression matchers added types must match.")
-        .option("--typeStrictNullChecks", "override TypeScript's --strictNullChecks setting for types")
-        .option("--typeOnlyPrimitives", "exclude complex types from changes, such as arrays or interfaces");
+        .option("-V --version", "output the package version");
     const parsedArgv = {
         ...(command.parse(rawArgv as string[]) as Partial<TypeStatArgv>),
         logger: runtime.logger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,29 +17,11 @@ import { createTypeStatProvider } from "./runtime/createTypeStatProvider";
 export interface TypeStatArgv {
     readonly args?: ReadonlyArray<string>;
     readonly config?: string;
-    readonly fileAbove?: string;
-    readonly fileBelow?: string;
-    readonly fileRenameExtensions?: boolean | "ts" | "tsx";
-    readonly filter?: string | ReadonlyArray<string>;
-    readonly fixIncompleteTypes?: boolean;
-    readonly fixMissingProperties?: boolean;
-    readonly fixNoImplicitAny?: boolean;
-    readonly fixStrictNonNullAssertions?: boolean;
-    readonly mutator?: string | ReadonlyArray<string>;
 
     /**
      * Wraps process.stderr and process.stdout.
      */
     readonly logger: ProcessLogger;
-
-    readonly packageDirectory?: string;
-    readonly packageFile?: string;
-    readonly packageMissingTypes?: true | "npm" | "yarn";
-    readonly project?: string;
-    readonly typeAlias?: string | ReadonlyArray<string>;
-    readonly typeMatching?: ReadonlyArray<string>;
-    readonly typeOnlyPrimitives?: boolean;
-    readonly typeStrictNullChecks?: boolean;
 }
 
 export enum ResultStatus {
@@ -92,7 +74,7 @@ export const typeStat = async (argv: TypeStatArgv): Promise<TypeStatResult> => {
 const tryLoadingOptions = async (argv: TypeStatArgv): Promise<TypeStatOptions | Error | string> => {
     let options: TypeStatOptions | string;
 
-    // First try loading options from the CLI and/or config file
+    // First try loading options from a config file
     try {
         options = await loadOptions(argv);
     } catch (error) {

--- a/src/mutators/builtIn/fixIncompleteTypes/README.md
+++ b/src/mutators/builtIn/fixIncompleteTypes/README.md
@@ -1,4 +1,4 @@
-# `--fixIncompleteTypes`/`incompleteTypes`
+# `incompleteTypes`
 
 Whether to augment type annotations that don't capture all values constructs can be set to.
 
@@ -10,10 +10,6 @@ Whether to augment type annotations that don't capture all values constructs can
 Note that `strictNullChecks` must be enabled in your `tsconfig.json` and/or TypeStat configuration file to add `| null` and `| undefined`.
 
 ## Configuration
-
-```shell
-typestat --fixIncompleteTypes
-```
 
 ```json
 {

--- a/src/mutators/builtIn/fixMissingProperties/README.md
+++ b/src/mutators/builtIn/fixMissingProperties/README.md
@@ -1,4 +1,4 @@
-# `--fixMissingProperties`/`missingProperties`
+# `missingProperties`
 
 Whether to apply TypeScript's fixer for missing properties on classes.
 
@@ -9,10 +9,6 @@ This entirely relies on TypeScript's suggested fixes to infer types from usage.
 * You're converting from JavaScript to TypeScript and have classes that contain properties
 
 ## Configuration
-
-```shell
-typestat --fixMissingProperties
-```
 
 ```json
 {

--- a/src/mutators/builtIn/fixNoImplicitAny/README.md
+++ b/src/mutators/builtIn/fixNoImplicitAny/README.md
@@ -1,4 +1,4 @@
-# `--fixNoImplicitAny`/`noImplicitAny`
+# `noImplicitAny`
 
 Whether to add type annotations to declarations that don't yet have them.
 
@@ -13,10 +13,6 @@ Places that don't need added types (i.e. would violate [`no-unnecessary-type-ann
 won't have them added.
 
 ## Configuration
-
-```shell
-typestat --fixNoImplicitAny
-```
 
 ```json
 {

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/README.md
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/README.md
@@ -1,4 +1,4 @@
-# `--fixStrictNonNullAssertions`/`strictNonNullAssertions`
+# `strictNonNullAssertions`
 
 Whether to add missing non-null assertions.
 
@@ -12,10 +12,6 @@ You'd like to enable [`--strictNullChecks`](https://basarat.gitbooks.io/typescri
 Note that `strictNullChecks` must be enabled in your `tsconfig.json` and/or TypeStat configuration file.
 
 ## Configuration
-
-```shell
-typestat --fixStrictNonNullAssertions
-```
 
 ```json
 {

--- a/src/options/fillOutRawOptions.ts
+++ b/src/options/fillOutRawOptions.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 
 import { TypeStatArgv } from "../index";
 import { processLogger } from "../logging/logger";
-import { arrayify, collectOptionals } from "../shared/arrays";
+import { collectOptionals } from "../shared/arrays";
 import { collectAsConfiguration } from "../shared/booleans";
 
 import { collectAddedMutators } from "./parsing/collectAddedMutators";
@@ -16,8 +16,8 @@ import { RawTypeStatOptions, TypeStatOptions } from "./types";
 export interface OptionsFromRawOptionsSettings {
     argv: TypeStatArgv;
     compilerOptions: Readonly<ts.CompilerOptions>;
+    cwd: string;
     fileNames?: ReadonlyArray<string>;
-    packageDirectory: string;
     projectPath: string;
     rawOptions: RawTypeStatOptions;
 }
@@ -30,36 +30,36 @@ export interface OptionsFromRawOptionsSettings {
 export const fillOutRawOptions = ({
     argv,
     compilerOptions,
+    cwd,
     fileNames,
-    packageDirectory,
     projectPath,
     rawOptions,
 }: OptionsFromRawOptionsSettings): TypeStatOptions | string => {
     const rawOptionTypes = rawOptions.types === undefined ? {} : rawOptions.types;
-    const noImplicitAny = collectNoImplicitAny(argv, compilerOptions, rawOptions);
-    const { compilerStrictNullChecks, typeStrictNullChecks } = collectStrictNullChecks(argv, compilerOptions, rawOptionTypes);
+    const noImplicitAny = collectNoImplicitAny(compilerOptions, rawOptions);
+    const { compilerStrictNullChecks, typeStrictNullChecks } = collectStrictNullChecks(compilerOptions, rawOptionTypes);
 
-    const typeAliases = collectTypeAliases(argv, rawOptionTypes);
+    const typeAliases = collectTypeAliases(rawOptionTypes);
     if (typeof typeAliases === "string") {
         return typeAliases;
     }
 
-    const packageOptions = collectPackageOptions(argv, packageDirectory, rawOptions);
+    const packageOptions = collectPackageOptions(cwd, rawOptions);
 
     const shell: ReadonlyArray<string>[] = [];
     if (rawOptions.postProcess !== undefined && rawOptions.postProcess.shell !== undefined) {
         shell.push(...rawOptions.postProcess.shell);
     }
 
-    const options = {
+    return {
         compilerOptions: {
             ...compilerOptions,
             noImplicitAny,
             strictNullChecks: compilerStrictNullChecks,
         },
         fileNames,
-        files: collectFileOptions(argv, rawOptions),
-        filters: collectOptionals(arrayify(argv.filter), rawOptions.filters),
+        files: collectFileOptions(rawOptions),
+        filters: collectOptionals(rawOptions.filters),
         fixes: {
             incompleteTypes: false,
             missingProperties: false,
@@ -68,33 +68,15 @@ export const fillOutRawOptions = ({
             ...rawOptions.fixes,
         },
         logger: argv.logger,
-        mutators: collectAddedMutators(argv, rawOptions, packageOptions.directory, processLogger),
+        mutators: collectAddedMutators(rawOptions, packageOptions.directory, processLogger),
         package: packageOptions,
         postProcess: { shell },
         projectPath,
         types: {
             aliases: typeAliases,
-            matching: argv.typeMatching === undefined ? rawOptionTypes.matching : argv.typeMatching,
-            onlyPrimitives: collectAsConfiguration(argv.typeOnlyPrimitives, rawOptionTypes.onlyPrimitives),
+            matching: rawOptionTypes.matching,
+            onlyPrimitives: collectAsConfiguration(rawOptionTypes.onlyPrimitives),
             strictNullChecks: typeStrictNullChecks,
         },
     };
-
-    if (argv.fixIncompleteTypes !== undefined) {
-        options.fixes.incompleteTypes = argv.fixIncompleteTypes;
-    }
-
-    if (argv.fixMissingProperties !== undefined) {
-        options.fixes.missingProperties = argv.fixMissingProperties;
-    }
-
-    if (argv.fixNoImplicitAny !== undefined) {
-        options.fixes.noImplicitAny = argv.fixNoImplicitAny;
-    }
-
-    if (argv.fixStrictNonNullAssertions !== undefined) {
-        options.fixes.strictNonNullAssertions = argv.fixStrictNonNullAssertions;
-    }
-
-    return options;
 };

--- a/src/options/findRawOptions.ts
+++ b/src/options/findRawOptions.ts
@@ -20,12 +20,12 @@ export interface FoundRawOptions {
 /**
  * Parses raw options from a configuration file.
  *
- * @param packageDirectory   Base directory to resolve paths from.
+ * @param cwd   Base directory to resolve paths from.
  * @param configPath   Suggested path to load from, instead of searching.
  * @returns Promise for parsed raw options from a configuration file.
  */
-export const findRawOptions = async (packageDirectory: string, configPath: string): Promise<FoundRawOptions | string> => {
-    const resolutionPath = path.join(packageDirectory, configPath);
+export const findRawOptions = async (cwd: string, configPath: string): Promise<FoundRawOptions | string> => {
+    const resolutionPath = path.join(cwd, configPath);
 
     let filePath: string;
     try {

--- a/src/options/parsing/collectAddedMutators.ts
+++ b/src/options/parsing/collectAddedMutators.ts
@@ -1,10 +1,9 @@
 import * as path from "path";
 
-import { TypeStatArgv } from "../../index";
 import { ProcessLogger } from "../../logging/logger";
 import { builtInFileMutators } from "../../mutators/builtIn";
 import { FileMutator } from "../../mutators/fileMutator";
-import { arrayify, collectOptionals } from "../../shared/arrays";
+import { collectOptionals } from "../../shared/arrays";
 import { getQuickErrorSummary } from "../../shared/errors";
 import { RawTypeStatOptions } from "../types";
 
@@ -15,19 +14,17 @@ interface ImportedFileMutator {
 /**
  * Finds mutators to use in runtime, as either the built-in mutators or custom mutators specified by the user.
  *
- * @param argv   Root arguments to pass to TypeStat.
  * @param rawOptions   Options listed as JSON in a typestat configuration file.
  * @param packageDirectory   Base directory to resolve paths from.
  * @param logger   Wraps process.stderr and process.stdout.
  * @returns Mutators to run with their friendly names.
  */
 export const collectAddedMutators = (
-    argv: TypeStatArgv,
     rawOptions: RawTypeStatOptions,
     packageDirectory: string,
     logger: ProcessLogger,
 ): ReadonlyArray<[string, FileMutator]> => {
-    const addedMutators = collectOptionals(arrayify(argv.mutator), rawOptions.mutators);
+    const addedMutators = collectOptionals(rawOptions.mutators);
     if (addedMutators.length === 0) {
         return builtInFileMutators;
     }

--- a/src/options/parsing/collectFileOptions.ts
+++ b/src/options/parsing/collectFileOptions.ts
@@ -1,30 +1,11 @@
-import { TypeStatArgv } from "../../index";
 import { Files, RawTypeStatOptions } from "../types";
 
-export const collectFileOptions = (argv: TypeStatArgv, rawOptions: RawTypeStatOptions): Files => {
+export const collectFileOptions = (rawOptions: RawTypeStatOptions): Files => {
     const files: Partial<Files> = rawOptions.files === undefined ? {} : { ...rawOptions.files };
-
-    if (argv.fileAbove !== undefined) {
-        files.above = argv.fileAbove;
-    }
-
-    if (argv.fileBelow !== undefined) {
-        files.below = argv.fileBelow;
-    }
-
-    let renameExtensions = argv.fileRenameExtensions;
-
-    if (renameExtensions === undefined) {
-        renameExtensions = files.renameExtensions;
-    }
-
-    if (renameExtensions === undefined) {
-        renameExtensions = false;
-    }
 
     return {
         above: files.above === undefined ? "" : files.above,
         below: files.below === undefined ? "" : files.below,
-        renameExtensions,
+        renameExtensions: files.renameExtensions === undefined ? false : files.renameExtensions,
     };
 };

--- a/src/options/parsing/collectNoImplicitAny.ts
+++ b/src/options/parsing/collectNoImplicitAny.ts
@@ -1,17 +1,8 @@
 import * as ts from "typescript";
 
-import { TypeStatArgv } from "../../index";
 import { RawTypeStatOptions } from "../types";
 
-export const collectNoImplicitAny = (
-    argv: TypeStatArgv,
-    compilerOptions: Readonly<ts.CompilerOptions>,
-    rawOptions: RawTypeStatOptions,
-): boolean => {
-    if (argv.fixNoImplicitAny !== undefined) {
-        return argv.fixNoImplicitAny;
-    }
-
+export const collectNoImplicitAny = (compilerOptions: Readonly<ts.CompilerOptions>, rawOptions: RawTypeStatOptions): boolean => {
     if (rawOptions.fixes !== undefined && rawOptions.fixes.noImplicitAny !== undefined) {
         return rawOptions.fixes.noImplicitAny;
     }

--- a/src/options/parsing/collectPackageOptions.ts
+++ b/src/options/parsing/collectPackageOptions.ts
@@ -1,22 +1,29 @@
 import * as path from "path";
 
-import { TypeStatArgv } from "../../index";
 import { normalizeAndSlashify } from "../../shared/paths";
 import { Package, RawTypeStatOptions } from "../types";
 
-export const collectPackageOptions = (argv: TypeStatArgv, packageDirectory: string, rawOptions: RawTypeStatOptions): Package => {
+export const collectPackageOptions = (cwd: string, rawOptions: RawTypeStatOptions): Package => {
     const rawPackageOptions = rawOptions.package === undefined ? {} : rawOptions.package;
+    const rawPackageFile = rawPackageOptions.file;
 
-    const rawPackageFile = argv.packageFile === undefined ? rawPackageOptions.file : argv.packageFile;
-
-    const file =
-        rawPackageFile === undefined || path.isAbsolute(rawPackageFile)
-            ? normalizeAndSlashify(path.join(packageDirectory, "package.json"))
-            : normalizeAndSlashify(rawPackageFile);
+    const file = collectRawPackageFile(cwd, rawPackageFile);
 
     return {
-        directory: packageDirectory,
+        directory: cwd,
         file,
-        missingTypes: argv.packageMissingTypes === undefined ? rawPackageOptions.missingTypes : argv.packageMissingTypes,
+        missingTypes: rawPackageOptions.missingTypes,
     };
+};
+
+const collectRawPackageFile = (cwd: string, rawPackageFile: string | undefined) => {
+    if (rawPackageFile === undefined) {
+        return normalizeAndSlashify(path.join(cwd, "package.json"));
+    }
+
+    if (path.isAbsolute(rawPackageFile)) {
+        return normalizeAndSlashify(rawPackageFile);
+    }
+
+    return normalizeAndSlashify(path.join(cwd, rawPackageFile));
 };

--- a/src/options/parsing/collectStrictNullChecks.ts
+++ b/src/options/parsing/collectStrictNullChecks.ts
@@ -1,16 +1,9 @@
 import * as ts from "typescript";
 
-import { TypeStatArgv } from "../../index";
 import { RawTypeStatTypeOptions } from "../types";
 
-export const collectStrictNullChecks = (
-    argv: TypeStatArgv,
-    compilerOptions: Readonly<ts.CompilerOptions>,
-    rawOptionTypes: RawTypeStatTypeOptions,
-) => {
-    const typeStrictNullChecks =
-        rawOptionTypes.strictNullChecks === undefined ? argv.typeStrictNullChecks : rawOptionTypes.strictNullChecks;
-
+export const collectStrictNullChecks = (compilerOptions: Readonly<ts.CompilerOptions>, rawOptionTypes: RawTypeStatTypeOptions) => {
+    const typeStrictNullChecks = rawOptionTypes.strictNullChecks;
     const compilerStrictNullChecks = collectCompilerStrictNullChecks(compilerOptions, typeStrictNullChecks);
 
     return { compilerStrictNullChecks, typeStrictNullChecks };

--- a/src/options/parsing/collectTypeAliases.ts
+++ b/src/options/parsing/collectTypeAliases.ts
@@ -1,22 +1,9 @@
-import { TypeStatArgv } from "../../index";
-import { arrayify } from "../../shared/arrays";
 import { convertObjectToMap } from "../../shared/maps";
 import { RawTypeStatTypeOptions } from "../types";
 
-export const collectTypeAliases = (argv: TypeStatArgv, rawOptionTypes: RawTypeStatTypeOptions): ReadonlyMap<RegExp, string> | string => {
+export const collectTypeAliases = (rawOptionTypes: RawTypeStatTypeOptions): ReadonlyMap<RegExp, string> | string => {
     const rawTypeAliases: Map<string, string> =
         rawOptionTypes.aliases === undefined ? new Map() : convertObjectToMap(rawOptionTypes.aliases);
-
-    if (argv.typeAlias !== undefined) {
-        for (const rawTypeAlias of arrayify(argv.typeAlias)) {
-            const keyAndValue = splitRawTypeAlias(rawTypeAlias);
-            if (keyAndValue === undefined) {
-                return `Improper type alias: '${rawTypeAlias}'. Format these as '--typeAlias key=value'.`;
-            }
-
-            rawTypeAliases.set(keyAndValue[0], keyAndValue[1]);
-        }
-    }
 
     const regexTypeAliases = new Map<RegExp, string>();
 
@@ -29,30 +16,4 @@ export const collectTypeAliases = (argv: TypeStatArgv, rawOptionTypes: RawTypeSt
     }
 
     return regexTypeAliases;
-};
-
-const splitRawTypeAlias = (rawTypeAlias: string): [string, string] | undefined => {
-    const splitIndex = getUnescapedEqualsIndex(rawTypeAlias);
-
-    return splitIndex <= 0 ? undefined : [rawTypeAlias.substring(0, splitIndex), rawTypeAlias.substring(splitIndex + 1)];
-};
-
-const getUnescapedEqualsIndex = (rawTypeAlias: string): number => {
-    let equalsIndex = 0;
-
-    while (true) {
-        equalsIndex = rawTypeAlias.indexOf("=", equalsIndex + 1);
-
-        if (equalsIndex === -1 || equalsIndex === rawTypeAlias.length - 1) {
-            break;
-        }
-
-        if (rawTypeAlias[equalsIndex - 1] === "\\") {
-            continue;
-        }
-
-        return equalsIndex;
-    }
-
-    return -1;
 };

--- a/src/tests/runTests.ts
+++ b/src/tests/runTests.ts
@@ -49,7 +49,7 @@ describeMutationTestCases(
             ...(fillOutRawOptions({
                 argv: { logger },
                 compilerOptions,
-                packageDirectory: path.dirname(projectPath),
+                cwd: path.dirname(projectPath),
                 projectPath,
                 rawOptions: {
                     ...rawOptions,


### PR DESCRIPTION
Simplifies the CLI to not allow --filter, --fixNoImplicitAny, and other settings that are now recommended to be only set in a config file. This simplifies a lot of logic around parsing raw arguments.

Fixes #38.