### PR TITLE
Mentioned number of files being visited by language services

### DIFF
--- a/src/runtime/providers/createCoreMutationsProvider.ts
+++ b/src/runtime/providers/createCoreMutationsProvider.ts
@@ -17,10 +17,7 @@ import { findMutationsInFile } from "../findMutationsInFile";
  * @param allModifiedFileNames   Set to mark names of all files that were modified.
  */
 export const createCoreMutationsProvider = (options: TypeStatOptions, allModifiedFiles: Set<string>) => {
-    const fileNamesAndServicesCache = new LazyCache(() => {
-        options.logger.stdout.write(chalk.grey("Preparing language services to visit files...\n"));
-        return createFileNamesAndServices(options);
-    });
+    const fileNamesAndServicesCache = createFileNamesAndServicesCache(options);
     let lastFileIndex = -1;
 
     return async (): Promise<IMutationsWave> => {
@@ -80,4 +77,15 @@ export const createCoreMutationsProvider = (options: TypeStatOptions, allModifie
                     : (convertMapToObject(fileMutations) as Dictionary<IMutation[]>),
         };
     };
+};
+
+const createFileNamesAndServicesCache = (options: TypeStatOptions) => {
+    return new LazyCache(() => {
+        options.logger.stdout.write(chalk.grey("Preparing language services to visit files...\n"));
+
+        const { fileNames, services } = createFileNamesAndServices(options);
+        options.logger.stdout.write(chalk.grey(`Prepared language services for ${fileNames.length} files...\n`));
+
+        return { fileNames, services };
+    });
 };


### PR DESCRIPTION
It needs to be a log _after_ the services are created because if no file names are passed in options, services are required to get that count.

Fixes #220.