### PR TITLE
Accounted for adjacent TypeScript codefix starts

### DIFF
--- a/src/mutations/codeFixes/creation.ts
+++ b/src/mutations/codeFixes/creation.ts
@@ -32,12 +32,13 @@ export const createCodeFixCreationMutation = (
         textChanges = textChanges.filter((textChange) => !knownBlankTypes.has(textChange.newText));
     }
 
-    if (textChanges.length === 0 || isOnlyParenthesis(textChanges)) {
+    const simplifiedTextChanges = simplifyTextChanges(textChanges);
+    if (simplifiedTextChanges === undefined) {
         return undefined;
     }
 
     return combineMutations(
-        ...textChanges.map(
+        ...simplifiedTextChanges.map(
             (textChange): ITextInsertMutation => ({
                 insertion: textChange.newText,
                 range: {
@@ -46,6 +47,38 @@ export const createCodeFixCreationMutation = (
                 type: "text-insert",
             }),
         ),
+    );
+};
+
+/**
+ * Reduces TypeScript-suggested text changes to their simplest form,
+ * for the case of two text changes with the same span start
+ * @see https://github.com/JoshuaKGoldberg/TypeStat/issues/256
+ */
+const simplifyTextChanges = (textChanges: readonly ts.TextChange[]) => {
+    if (textChanges.length === 0 || isOnlyParenthesis(textChanges)) {
+        return undefined;
+    }
+
+    return textChanges.slice(1).reduce(
+        (previousValues, textChange) => {
+            const previousValue = previousValues[previousValues.length - 1];
+
+            // If the span starts aren't the same, there's nothing we can simplify
+            if (previousValue.span.start !== textChange.span.start) {
+                return [...previousValues, textChange];
+            }
+
+            // Since two text changes in a row have the same start, rejoice!
+            // We can combine them into a single value and lessen the array size
+            previousValues[previousValues.length - 1] = {
+                ...previousValue,
+                newText: `${previousValue.newText}${textChange.newText}`,
+            };
+
+            return previousValues;
+        },
+        [textChanges[0]],
     );
 };
 

--- a/test/cases/unit/parameters/all/expected.ts
+++ b/test/cases/unit/parameters/all/expected.ts
@@ -58,4 +58,10 @@
     ['notGivenInferableTypes'].forEach((char, index) => {
         console.log(char, index);
     })
+
+    const needsWrapping = count => `${count}lbs`;
+    needsWrapping(1.234567);
+
+    const needsNoWrapping = (count) => `${count}lbs`;
+    needsNoWrapping(1.234567);
 })();

--- a/test/cases/unit/parameters/default/expected.ts
+++ b/test/cases/unit/parameters/default/expected.ts
@@ -58,4 +58,10 @@
     ['notGivenInferableTypes'].forEach((char, index) => {
         console.log(char, index);
     })
+
+    const needsWrapping = count => `${count}lbs`;
+    needsWrapping(1.234567);
+
+    const needsNoWrapping = (count) => `${count}lbs`;
+    needsNoWrapping(1.234567);
 })();

--- a/test/cases/unit/parameters/incompleteTypes/expected.ts
+++ b/test/cases/unit/parameters/incompleteTypes/expected.ts
@@ -58,4 +58,10 @@
     ['notGivenInferableTypes'].forEach((char, index) => {
         console.log(char, index);
     })
+
+    const needsWrapping = count => `${count}lbs`;
+    needsWrapping(1.234567);
+
+    const needsNoWrapping = (count) => `${count}lbs`;
+    needsNoWrapping(1.234567);
 })();

--- a/test/cases/unit/parameters/noImplicitAny/expected.ts
+++ b/test/cases/unit/parameters/noImplicitAny/expected.ts
@@ -58,4 +58,10 @@
     ['notGivenInferableTypes'].forEach((char, index) => {
         console.log(char, index);
     })
+
+    const needsWrapping = (count: number) => `${count}lbs`;
+    needsWrapping(1.234567);
+
+    const needsNoWrapping = (count: number) => `${count}lbs`;
+    needsNoWrapping(1.234567);
 })();

--- a/test/cases/unit/parameters/original.ts
+++ b/test/cases/unit/parameters/original.ts
@@ -58,4 +58,10 @@
     ['notGivenInferableTypes'].forEach((char, index) => {
         console.log(char, index);
     })
+
+    const needsWrapping = count => `${count}lbs`;
+    needsWrapping(1.234567);
+
+    const needsNoWrapping = (count) => `${count}lbs`;
+    needsNoWrapping(1.234567);
 })();

--- a/test/cases/unit/parameters/strictNonNullAssertions/expected.ts
+++ b/test/cases/unit/parameters/strictNonNullAssertions/expected.ts
@@ -58,4 +58,10 @@
     ['notGivenInferableTypes'].forEach((char, index) => {
         console.log(char, index);
     })
+
+    const needsWrapping = count => `${count}lbs`;
+    needsWrapping(1.234567);
+
+    const needsNoWrapping = (count) => `${count}lbs`;
+    needsNoWrapping(1.234567);
 })();


### PR DESCRIPTION
Fixes #256.

We _could_ reverse the order of TypeScript codefixes... but that seems hacky.