### PR TITLE
Stopped filtering out non-alphanumeric text changes from TypeScript

### DIFF
--- a/src/mutations/codeFixes/processCodeFixActions.ts
+++ b/src/mutations/codeFixes/processCodeFixActions.ts
@@ -39,6 +39,11 @@ export const processCodeFixActions = (
     };
 
     const processTextChange = (textChange: ts.TextChange): ts.TextChange | undefined => {
+        // Triva text changes, such as "(" and ")", don't need to be checked for codefixes
+        if (!/[a-z0-9]/i.test(textChange.newText)) {
+            return textChange;
+        }
+
         const processedUnionTypes = extractRawCodefixUnionTypes(request, textChange.newText);
         if (processedUnionTypes === undefined || processedUnionTypes.length === 0) {
             return undefined;


### PR DESCRIPTION
Followup PR to #374. I was still seeing some symptoms of the original bug (#256) that was supposed to solve. Annoying!

As it turns out, when TypeScript proposed the following text changes:

* `"("`
* `": string"`
* `")"`

...then TypeStat was filtering out the first and last when `types.onlyPrimitives` was on, in an attempt to prevent complex types.