### PR TITLE
Allowed an array of configurations in addition to just one

### DIFF
--- a/src/options/optionVerification.ts
+++ b/src/options/optionVerification.ts
@@ -1,6 +1,6 @@
 import { TypeStatOptions } from "./types";
 
-export const findComplaintForOptions = (options: TypeStatOptions | string): string | undefined => {
+export const findComplaintForOptions = (options: TypeStatOptions | string): TypeStatOptions | string => {
     if (typeof options === "string") {
         return options;
     }
@@ -13,7 +13,7 @@ export const findComplaintForOptions = (options: TypeStatOptions | string): stri
         return "--fixStrictNonNullAssertions specified but not strictNullChecks. Consider enabling --typeStrictNullChecks (see http://github.com/joshuakgoldberg/typestat/blob/master/docs/Fixes.md).";
     }
 
-    return undefined;
+    return options;
 };
 
 const noFixesSpecified = (options: TypeStatOptions): boolean =>

--- a/src/options/processFileRenames.ts
+++ b/src/options/processFileRenames.ts
@@ -2,8 +2,8 @@ import { fs } from "mz";
 
 import { TypeStatOptions } from "./types";
 
-export const processFileRenames = async (options: TypeStatOptions): Promise<TypeStatOptions | string> => {
-    if (options.fileNames === undefined) {
+export const processFileRenames = async (options: TypeStatOptions | string): Promise<TypeStatOptions | string> => {
+    if (typeof options === "string" || options.fileNames === undefined) {
         return options;
     }
 


### PR DESCRIPTION
Fixes #119.

This closes the loop on the changes around multi-step config generation introduced in #283. Configs are now stored as an array of options, which are then looped over in `typeStat`.