### PR TITLE
Corrected '--' style links for docs

### DIFF
--- a/src/mutations/codeFixes/extractRawCodefixUnionTypes.ts
+++ b/src/mutations/codeFixes/extractRawCodefixUnionTypes.ts
@@ -20,7 +20,7 @@ const keywordLiteralEquivalents = new Map([
 ]);
 
 /**
- * Nodes types known to be literals allowed in --typesOnlyPrimitives.
+ * Nodes types known to be literals allowed in types.onlyPrimitives.
  */
 const primitiveNodeKinds = new Set([
     ...keywordLiteralEquivalents.keys(),

--- a/src/options/optionVerification.ts
+++ b/src/options/optionVerification.ts
@@ -6,11 +6,11 @@ export const findComplaintForOptions = (options: TypeStatOptions | string): Type
     }
 
     if (noFixesSpecified(options)) {
-        return "No fixes or custom mutators specified. Consider enabling --fixNoImplicitAny (see http://github.com/joshuakgoldberg/typestat#cli).";
+        return "No fixes or custom mutators specified. Consider enabling fixes.noImplicitAny (see http://github.com/joshuakgoldberg/typestat#cli).";
     }
 
     if (strictNonNullAssertionsInNonStrictMode(options)) {
-        return "--fixStrictNonNullAssertions specified but not strictNullChecks. Consider enabling --typeStrictNullChecks (see http://github.com/joshuakgoldberg/typestat/blob/master/docs/Fixes.md).";
+        return "fixes.strictNonNullAssertions specified but not strictNullChecks. Consider enabling types.strictNullChecks (see http://github.com/joshuakgoldberg/typestat/blob/main/docs/Fixes.md).";
     }
 
     return options;

--- a/src/options/processFileRenames.ts
+++ b/src/options/processFileRenames.ts
@@ -78,8 +78,9 @@ const ensureNoJsFiles = async (options: TypeStatOptions, fileNames: ReadonlyArra
     }
 
     return [
-        "The following JavaScript files were included in the project but --fileRenameExtensions is not enabled.",
+        "The following JavaScript files were included in the project but files.renameExtensions is not enabled.",
         "TypeStat does not yet support annotating JavaScript files.",
         ...jsFileNames.map((fileName) => `\t${fileName}`),
+        "See https://github.com/JoshuaKGoldberg/TypeStat/blob/main/docs/Files.md for details.",
     ].join("\n");
 };


### PR DESCRIPTION
Fixes #243.

Directly adds a _"see (link) for details"_ to the extension rename complaint for JS files. I also noticed it was still referring to the old `--fileRenameExtensions` kind of CLI option setting that isn't supported anymore, so I fixed up the last few places I could find like that in code.