### PR TITLE
Don't add non-null assertions for any-typed parameters

### DIFF
--- a/test/cases/fixes/missingProperties/missingPropertyAccesses/expected.ts
+++ b/test/cases/fixes/missingProperties/missingPropertyAccesses/expected.ts
@@ -5,6 +5,7 @@ givenNumberOrUndefined: number | undefined;
 givenUndefined: undefined;
 givenTwiceSame: number;
 givenTwiceDifferent: number;
+private _withGetterAndSetter: string;
         def() {
             this.givenNumber = 1;
             this.givenNumberOrUndefined = 1 as number | undefined;
@@ -16,5 +17,14 @@ givenTwiceDifferent: number;
             this.givenTwiceDifferent = 1;
             this.givenTwiceDifferent = undefined;
         }
+
+        set withGetterAndSetter(value: string) {
+            this._withGetterAndSetter = value;
+        }
+
+        get withGetterAndSetter() {
+            return this._withGetterAndSetter;
+        }
+
     }
 })();

--- a/test/cases/fixes/missingProperties/missingPropertyAccesses/original.ts
+++ b/test/cases/fixes/missingProperties/missingPropertyAccesses/original.ts
@@ -11,5 +11,14 @@
             this.givenTwiceDifferent = 1;
             this.givenTwiceDifferent = undefined;
         }
+
+        set withGetterAndSetter(value: string) {
+            this._withGetterAndSetter = value;
+        }
+
+        get withGetterAndSetter() {
+            return this._withGetterAndSetter;
+        }
+
     }
 })();

--- a/test/cases/fixes/strictNonNullAssertions/callExpressions/expected.ts
+++ b/test/cases/fixes/strictNonNullAssertions/callExpressions/expected.ts
@@ -25,6 +25,16 @@
     function twoParametersStringBecomesUndefinedDirect(abc: string, def: string) { }
     twoParametersStringBecomesUndefinedDirect(undefined!, undefined!);
 
+    function takesStringFromAny(value: string) { }
+    function givesAnyToString(maybe: any | undefined) {
+        takesStringFromAny(maybe);
+    }
+
+    function takesAnyFromString(value: any) { }
+    function givesStringToAny(maybe: string | undefined) {
+        takesAnyFromString(maybe);
+    }
+
     function takesString(abc: string) { }
     takesString(null!);
     takesString(undefined!);

--- a/test/cases/fixes/strictNonNullAssertions/callExpressions/original.ts
+++ b/test/cases/fixes/strictNonNullAssertions/callExpressions/original.ts
@@ -25,6 +25,16 @@
     function twoParametersStringBecomesUndefinedDirect(abc: string, def: string) { }
     twoParametersStringBecomesUndefinedDirect(undefined, undefined);
 
+    function takesStringFromAny(value: string) { }
+    function givesAnyToString(maybe: any | undefined) {
+        takesStringFromAny(maybe);
+    }
+
+    function takesAnyFromString(value: any) { }
+    function givesStringToAny(maybe: string | undefined) {
+        takesAnyFromString(maybe);
+    }
+
     function takesString(abc: string) { }
     takesString(null);
     takesString(undefined);


### PR DESCRIPTION


## PR Checklist

-   [x] Addresses an existing issue: fixes #48
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Checks if the parameter has the `any` flag set recursively, and skips creating the mutation if so.