### PR TITLE
Stopped incompleteTypes fixer on type-less nodes

### DIFF
--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteParameterTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteParameterTypes/index.ts
@@ -2,12 +2,14 @@ import { IMutation } from "automutate";
 import * as ts from "typescript";
 
 import { createTypeAdditionMutation, createTypeCreationMutation } from "../../../../mutations/creators";
-import { isNodeWithType } from "../../../../shared/nodeTypes";
+import { isNodeWithType, NodeWithType } from "../../../../shared/nodeTypes";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
 
 export const fixIncompleteParameterTypes: FileMutator = (request: FileMutationsRequest): ReadonlyArray<IMutation> =>
-    collectMutationsFromNodes(request, ts.isParameter, visitParameterDeclaration);
+    collectMutationsFromNodes(request, isParameterWithType, visitParameterDeclaration);
+
+const isParameterWithType = (node: ts.Node): node is ts.ParameterDeclaration & NodeWithType => ts.isParameter(node) && isNodeWithType(node);
 
 const visitParameterDeclaration = (node: ts.ParameterDeclaration, request: FileMutationsRequest): IMutation | undefined => {
     // Collect types initially assigned or later called with as the parameter

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
@@ -4,12 +4,15 @@ import * as ts from "typescript";
 
 import { createTypeAdditionMutation, createTypeCreationMutation } from "../../../../mutations/creators";
 import { isNodeAssigningBinaryExpression } from "../../../../shared/nodes";
-import { isNodeWithType } from "../../../../shared/nodeTypes";
+import { isNodeWithType, NodeWithType } from "../../../../shared/nodeTypes";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
 
 export const fixIncompletePropertyDeclarationTypes: FileMutator = (request: FileMutationsRequest): ReadonlyArray<IMutation> =>
-    collectMutationsFromNodes(request, ts.isPropertyDeclaration, visitPropertyDeclaration);
+    collectMutationsFromNodes(request, isPropertyDeclarationWithType, visitPropertyDeclaration);
+
+const isPropertyDeclarationWithType = (node: ts.Node): node is ts.PropertyDeclaration & NodeWithType =>
+    ts.isPropertyDeclaration(node) && isNodeWithType(node);
 
 const visitPropertyDeclaration = (node: ts.PropertyDeclaration, request: FileMutationsRequest): IMutation | undefined => {
     // Collect types later assigned to the property, and types initially declared by or inferred on the property

--- a/test/cases/fixes/incompleteTypes/parameterTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/parameterTypes/expected.ts
@@ -1,11 +1,11 @@
 (function () {
-    function takesNumber(one: number) { }
+    function takesNumber(one) { }
     takesNumber(1);
 
-    function takesStringThenBoolean(one: string, two: boolean) { }
+    function takesStringThenBoolean(one, two) { }
     takesStringThenBoolean('abc', true);
 
-    function takesStringOrBoolean(one: boolean | string) { }
+    function takesStringOrBoolean(one) { }
     function passesStringOrBoolean(input: string | boolean) {
         takesStringOrBoolean(input);
     }

--- a/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/expected.ts
@@ -1,6 +1,6 @@
 (function () {
     class WithMissingString {
-        property: string;
+        property;
     }
     new WithMissingString().property = "abc";
 
@@ -10,7 +10,7 @@
     new WithMissingString().property = "abc";
 
     class WithMissingStringOrNumber {
-        property: number | string;
+        property;
     }
     function setWithMissingStringOrNumber(instance: WithMissingStringOrNumber, value: string | number) {
         instance.property = value;
@@ -21,5 +21,15 @@
     }
     function setWithExplicitStringMissingNumber(instance: WithExplicitStringMissingNumber, value: string | number) {
         instance.property = value;
+    }
+
+    class WithObjectProperty {
+        member;
+
+        method() {
+            this.member = {
+                key: true,
+            }
+        }
     }
 })();

--- a/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/original.ts
@@ -22,4 +22,14 @@
     function setWithExplicitStringMissingNumber(instance: WithExplicitStringMissingNumber, value: string | number) {
         instance.property = value;
     }
+
+    class WithObjectProperty {
+        member;
+
+        method() {
+            this.member = {
+                key: true,
+            }
+        }
+    }
 })();

--- a/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
@@ -1,7 +1,7 @@
 (function () {
     // Primitives
 
-    let givenUndefined: string | undefined = "";
+    let givenUndefined = "";
     givenUndefined = undefined;
 
     let givenUndefinedAsString: string | undefined = "";
@@ -14,7 +14,7 @@
     givenNullAndUndefinedHasNull = null;
     givenNullAndUndefinedHasNull = undefined;
 
-    let givenNull: string | null = "";
+    let givenNull = "";
     givenNull = null;
 
     let givenNullAsString: string | null = "";
@@ -27,7 +27,7 @@
     givenNullAndUndefinedHasUndefined = null;
     givenNullHasUndefined = undefined;
 
-    let givenString: string;
+    let givenString;
     givenString = "";
 
     let givenStringAsString: string = "";
@@ -104,13 +104,13 @@
     let onlyClassOneExplicitClass: SampleClassOne = new SampleClassOne();
     let onlyClassOneExplicitInterface: SampleInterface = new SampleClassOne();
 
-    let eitherClassImplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
+    let eitherClassImplicit = new SampleClassOne();
     eitherClassImplicit = new SampleClassTwo();
 
     let eitherClassExplicit: SampleInterface = new SampleClassOne();
     eitherClassExplicit = new SampleClassTwo();
 
-    let eitherClassNeedsUnionImplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
+    let eitherClassNeedsUnionImplicit = new SampleClassOne();
     eitherClassNeedsUnionImplicit = new SampleClassTwo();
 
     let eitherClassNeedsUnionExplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
@@ -119,7 +119,7 @@
     let eitherClassNeedsUnionExplicitInterface: SampleInterface = new SampleClassOne();
     eitherClassNeedsUnionExplicitInterface = new SampleClassTwo();
 
-    let eitherClassNeedsNullImplicit: SampleClassOne | SampleClassTwo | null = new SampleClassOne();
+    let eitherClassNeedsNullImplicit = new SampleClassOne();
     eitherClassNeedsNullImplicit = new SampleClassTwo();
     eitherClassNeedsNullImplicit = null;
 

--- a/test/cases/fixes/noImplicitAny/variableDeclarations/expected.ts
+++ b/test/cases/fixes/noImplicitAny/variableDeclarations/expected.ts
@@ -1,7 +1,7 @@
 (function () {
     // Primitives
 
-    let givenUndefined: string | undefined = "";
+    let givenUndefined = "";
     givenUndefined = undefined;
 
     let givenUndefinedAsString: string | undefined = "";
@@ -14,7 +14,7 @@
     givenNullAndUndefinedHasNull = null;
     givenNullAndUndefinedHasNull = undefined;
 
-    let givenNull: string | null = "";
+    let givenNull = "";
     givenNull = null;
 
     let givenNullAsString: string | null = "";
@@ -27,7 +27,7 @@
     givenNullAndUndefinedHasUndefined = null;
     givenNullHasUndefined = undefined;
 
-    let givenString: string;
+    let givenString;
     givenString = "";
 
     let givenStringAsString: string = "";
@@ -121,13 +121,13 @@
     let onlyClassOneExplicitClass: SampleClassOne = new SampleClassOne();
     let onlyClassOneExplicitInterface: SampleInterface = new SampleClassOne();
 
-    let eitherClassImplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
+    let eitherClassImplicit = new SampleClassOne();
     eitherClassImplicit = new SampleClassTwo();
 
     let eitherClassExplicit: SampleInterface = new SampleClassOne();
     eitherClassExplicit = new SampleClassTwo();
 
-    let eitherClassNeedsUnionImplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
+    let eitherClassNeedsUnionImplicit = new SampleClassOne();
     eitherClassNeedsUnionImplicit = new SampleClassTwo();
 
     let eitherClassNeedsUnionExplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
@@ -136,7 +136,7 @@
     let eitherClassNeedsUnionExplicitInterface: SampleInterface = new SampleClassOne();
     eitherClassNeedsUnionExplicitInterface = new SampleClassTwo();
 
-    let eitherClassNeedsNullImplicit: SampleClassOne | SampleClassTwo | null = new SampleClassOne();
+    let eitherClassNeedsNullImplicit = new SampleClassOne();
     eitherClassNeedsNullImplicit = new SampleClassTwo();
     eitherClassNeedsNullImplicit = null;
 
@@ -188,7 +188,7 @@
 
     // Functions
 
-    let resolve: (() => void);
+    let resolve;
     resolve = () => { };
 
     new Promise<void>((_resolve) => {

--- a/test/cases/types/onlyPrimitives/false/expected.ts
+++ b/test/cases/types/onlyPrimitives/false/expected.ts
@@ -20,19 +20,19 @@
     receivesFooOrString(new Foo());
     receivesFooOrString("");
 
-    function stringOrBoolean(): string {
+    function stringOrBoolean(): string | boolean {
         return true;
     }
 
-    function stringOrUndefined(): string {
+    function stringOrUndefined(): string | undefined {
         return undefined;
     }
 
-    function stringOrClass(): string {
+    function stringOrClass(): string | Foo {
         return new Foo();
     }
 
-    function stringOrFunction(): string {
+    function stringOrFunction(): string | (() => void) {
         return () => {};
     }
 
@@ -59,15 +59,15 @@
     instanceEitherOrText = new Bar();
     instanceEitherOrText = "";
 
-    function receivesText(text: string) {}
+    function receivesText(text) {}
     receivesText(text);
 
-    function receivesTextOrInstance(text: string) {}
+    function receivesTextOrInstance(text) {}
     receivesTextOrInstance(text);
 
-    function receivesInstanceEither(either: Bar) {}
+    function receivesInstanceEither(either) {}
     receivesInstanceEither(instanceEither);
 
-    function receivesInstanceEitherOrText(either: Bar) {}
+    function receivesInstanceEitherOrText(either) {}
     receivesInstanceEitherOrText(instanceEither);
 })();

--- a/test/cases/types/onlyPrimitives/true/expected.ts
+++ b/test/cases/types/onlyPrimitives/true/expected.ts
@@ -20,11 +20,11 @@
     receivesFooOrString(new Foo());
     receivesFooOrString("");
 
-    function stringOrBoolean(): string {
+    function stringOrBoolean(): string | boolean {
         return true;
     }
 
-    function stringOrUndefined(): string {
+    function stringOrUndefined(): string | undefined {
         return undefined;
     }
 
@@ -59,10 +59,10 @@
     instanceEitherOrText = new Bar();
     instanceEitherOrText = "";
 
-    function receivesText(text: string) {}
+    function receivesText(text) {}
     receivesText(text);
 
-    function receivesTextOrInstance(text: string) {}
+    function receivesTextOrInstance(text) {}
     receivesTextOrInstance(text);
 
     function receivesInstanceEither(either) {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to TypeStat! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #739
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds an `isNodeWithType` check before fixing for incomplete property, parameter, and variable types.