### PR TITLE
Added type expansions for plain Functions

### DIFF
--- a/src/mutations/collecting.ts
+++ b/src/mutations/collecting.ts
@@ -2,6 +2,7 @@ import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
 import { FileMutationsRequest } from "../mutators/fileMutator";
+import { isKnownGlobalBaseType } from "../shared/nodeTypes";
 import { setSubtract } from "../shared/sets";
 
 import { getApplicableTypeAliases } from "./aliasing/aliases";
@@ -23,7 +24,8 @@ export const collectUsageFlagsAndSymbols = (
     const [assignedFlags, assignedTypes] = collectFlagsAndTypesFromTypes(request, allAssignedTypes);
 
     // If the declared type is the general 'any', then we assume all are missing
-    if (declaredType.flags & ts.TypeFlags.Any) {
+    // Similarly, if it's a plain Function or Object, we'll want to replace its contents
+    if (declaredType.flags & ts.TypeFlags.Any || isKnownGlobalBaseType(declaredType)) {
         return {
             assignedFlags,
             assignedTypes,

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -25,7 +25,7 @@ export const createTypeAdditionMutation = (
     // Find any missing flags and symbols (a.k.a. types)
     const { missingFlags, missingTypes } = collectUsageFlagsAndSymbols(request, declaredType, allAssignedTypes);
 
-    // Otherwise, if nothing is missing, rejoice! The type was already fine.
+    // If nothing is missing, rejoice! The type was already fine.
     if (missingFlags.size === 0 && missingTypes.size === 0) {
         return undefined;
     }

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -122,5 +122,5 @@ const knownGlobalBaseTypeNames = new Set<string | undefined>(["Function"]);
  * @returns Whether the type is a known base type such as Function.
  */
 export const isKnownGlobalBaseType = (type: ts.Type) => {
-    return knownGlobalBaseTypeNames.has(isIntrisinicNameTypeNode(type) ? type.intrinsicName : type.getSymbol()?.escapedName.toString());
+    return knownGlobalBaseTypeNames.has(type.getSymbol()?.escapedName.toString());
 };

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -116,6 +116,7 @@ export const getIdentifyingTypeLiteralParent = (node: ts.TypeLiteralNode) => {
 };
 
 // Todo: eventually, these should expand to object, Object, etc...
+// Those are stored as intrinsicNames on types, and were showing up without missing flags for some reason
 const knownGlobalBaseTypeNames = new Set<string | undefined>(["Function"]);
 
 /**

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 
 import { isTypeFlagSetRecursively } from "../mutations/collecting/flags";
+import { isIntrisinicNameTypeNode } from "./typeNodes";
 
 export type NodeSelector<TNode extends ts.Node> = (node: ts.Node) => node is TNode;
 
@@ -112,4 +113,14 @@ export const getIdentifyingTypeLiteralParent = (node: ts.TypeLiteralNode) => {
 
     // ???
     return node;
+};
+
+// Todo: eventually, these should expand to object, Object, etc...
+const knownGlobalBaseTypeNames = new Set<string | undefined>(["Function"]);
+
+/**
+ * @returns Whether the type is a known base type such as Function.
+ */
+export const isKnownGlobalBaseType = (type: ts.Type) => {
+    return knownGlobalBaseTypeNames.has(isIntrisinicNameTypeNode(type) ? type.intrinsicName : type.getSymbol()?.escapedName.toString());
 };

--- a/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
@@ -171,10 +171,10 @@
 
     // Functions
 
-    let resolve: () => void;
-    resolve = () => { };
+    let returnsString: (() => string);
+    returnsString = () => "";
 
-    new Promise<void>((_resolve) => {
-        resolve = _resolve;
-    });
+    let returnsStringOrNumber: (() => string) | (() => number);
+    returnsStringOrNumber = () => "";
+    returnsStringOrNumber = () => 0;
 })();

--- a/test/cases/fixes/incompleteTypes/variableTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/variableTypes/original.ts
@@ -171,10 +171,10 @@
 
     // Functions
 
-    let resolve: () => void;
-    resolve = () => { };
+    let returnsString: Function;
+    returnsString = () => "";
 
-    new Promise<void>((_resolve) => {
-        resolve = _resolve;
-    });
+    let returnsStringOrNumber: Function;
+    returnsStringOrNumber = () => "";
+    returnsStringOrNumber = () => 0;
 })();


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #257
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds a hardcoding for `"Function"` as a name of an object in both collection and expansion: when hit, the original type will be ignored and replaced with more specific function type(s).