### PR TITLE
Added Function type expansion to React props

### DIFF
--- a/src/mutations/expansions/eliminations.ts
+++ b/src/mutations/expansions/eliminations.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 
 import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { isKnownGlobalBaseType } from "../../shared/nodeTypes";
 
 /**
  * @returns Whether any of the extra types don't yet exist on an original type.
@@ -12,5 +13,12 @@ export const originalTypeHasIncompleteType = (
 ) => {
     const typeChecker = request.services.program.getTypeChecker();
 
+    // If the original type is something like Function and at least one candidate type isn't,
+    // consider the Function to be reporting not enough info (like a base type)
+    if (isKnownGlobalBaseType(originalType) && !candidateTypes.every(isKnownGlobalBaseType)) {
+        return true;
+    }
+
+    // Otherwise we can directly use isTypeAssignableTo checking
     return candidateTypes.some((assignedType) => !typeChecker.isTypeAssignableTo(assignedType, originalType));
 };

--- a/src/mutations/expansions/expansionMutations.ts
+++ b/src/mutations/expansions/expansionMutations.ts
@@ -11,6 +11,7 @@ import { addIncompleteTypesToType, TypeSummariesPerNodeByName } from "./addIncom
 import { addMissingTypesToType } from "./addMissingTypesToType";
 import { originalTypeHasIncompleteType } from "./eliminations";
 import { summarizeAllAssignedTypes, TypeSummariesByName } from "./summarization";
+import { isNodeWithType, PropertySignatureWithType } from "../../shared/nodeTypes";
 
 /**
  * Given an interface or type declaration and a set of later-assigned types,
@@ -37,7 +38,7 @@ export const createTypeExpansionMutation = (
         // If the type matches an existing property in name but not in type, we'll add the new type in there
         const originalPropertyType = request.services.program.getTypeChecker().getTypeAtLocation(originalProperty);
         if (originalTypeHasIncompleteType(request, originalPropertyType, summary.types)) {
-            incompleteTypes.set(name, { originalProperty, summary });
+            incompleteTypes.set(name, { originalProperty, originalPropertyType, summary });
         }
     }
 
@@ -49,11 +50,11 @@ export const createTypeExpansionMutation = (
 };
 
 const groupPropertyDeclarationsByName = (node: ts.InterfaceDeclaration | ts.TypeLiteralNode) => {
-    const propertiesByName: Map<string, ts.PropertySignature> = new Map();
+    const propertiesByName: Map<string, PropertySignatureWithType> = new Map();
 
     for (const member of node.members) {
         // Ignore non-existent or implicitly typed members
-        if (!ts.isPropertySignature(member) || member.type === undefined) {
+        if (!ts.isPropertySignature(member) || !isNodeWithType(member)) {
             continue;
         }
 

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -25,6 +25,8 @@ export type NodeWithIdentifierName = ts.Node & {
 
 export type ParameterDeclarationWithType = ts.ParameterDeclaration & NodeWithType;
 
+export type PropertySignatureWithType = ts.PropertySignature & NodeWithType;
+
 /**
  * Node types TypeStat may attempt to create a type declaration on.
  */

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromLaterAssignments/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromLaterAssignments/expected.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 
 (function () {
-    // interface ClassComponentProps {
-    //     other?: boolean;
-    // }
+    interface ClassComponentProps {
+        other?: boolean;
+text?: string;
+    }
 
-    // class ClassComponent extends React.Component<ClassComponentProps> {
-    //     render() {
-    //         return this.props.text;    
-    //     }
-    // }
+    class ClassComponent extends React.Component<ClassComponentProps> {
+        render() {
+            return this.props.text;    
+        }
+    }
 
-    // const renderClassComponent = (text: string) =>
-    //     <ClassComponent text={text} />;
+    const renderClassComponent = (text: string) =>
+        <ClassComponent text={text} />;
         
     // TODO: This should be string[] or Array<string>, not Array...
     type FunctionComponentProps =  {
@@ -28,4 +29,16 @@ texts?: Array;
 
     const renderFunctionComponent = (texts: string[]) =>
         <FunctionComponent texts={texts} />;
+
+    type WithFunctionsProps = {
+        returnsBoolean: (() => boolean);
+        returnsStringOrNumber: () => string | (() => number);
+    }
+
+    class WithFunctions extends React.Component<WithFunctionsProps> { }
+
+    const withFunctions = <WithFunctions
+        returnsBoolean={() => false}
+        returnsStringOrNumber={() => 0}
+    />;
 })();

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromLaterAssignments/original.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromLaterAssignments/original.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
 (function () {
-    // interface ClassComponentProps {
-    //     other?: boolean;
-    // }
+    interface ClassComponentProps {
+        other?: boolean;
+    }
 
-    // class ClassComponent extends React.Component<ClassComponentProps> {
-    //     render() {
-    //         return this.props.text;    
-    //     }
-    // }
+    class ClassComponent extends React.Component<ClassComponentProps> {
+        render() {
+            return this.props.text;    
+        }
+    }
 
-    // const renderClassComponent = (text: string) =>
-    //     <ClassComponent text={text} />;
+    const renderClassComponent = (text: string) =>
+        <ClassComponent text={text} />;
         
     // TODO: This should be string[] or Array<string>, not Array...
     type FunctionComponentProps =  {
@@ -27,4 +27,16 @@ import React from 'react';
 
     const renderFunctionComponent = (texts: string[]) =>
         <FunctionComponent texts={texts} />;
+
+    type WithFunctionsProps = {
+        returnsBoolean: Function;
+        returnsStringOrNumber: () => string;
+    }
+
+    class WithFunctions extends React.Component<WithFunctionsProps> { }
+
+    const withFunctions = <WithFunctions
+        returnsBoolean={() => false}
+        returnsStringOrNumber={() => 0}
+    />;
 })();


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to TypeStat! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #258
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Copies (😦) some of the logic from `createTypeAdditionMutation` to `createTypeExpansionMutation`. Not super sure why both have organically grown but I don't see a quick & easy way to deduplicate... I guess this is ok for now.  