### PR TITLE
Prevented duplicate TypeScript property inferences

### DIFF
--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/collectGenericNodeReferences.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/collectGenericNodeReferences.ts
@@ -67,7 +67,11 @@ export const expandReferencesForGenericTypes = (
 
         // The templated declaration is the backing value declaration for the instantiation's symbol
         const templatedDeclaration = templatedDeclarationSymbol.valueDeclaration;
-        if (!isNodeWithDefinedTypeParameters(templatedDeclaration) || templatedParentInstantiation.typeArguments === undefined) {
+        if (
+            templatedDeclaration === undefined ||
+            !isNodeWithDefinedTypeParameters(templatedDeclaration) ||
+            templatedParentInstantiation.typeArguments === undefined
+        ) {
             continue;
         }
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #755; fixes #756
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Applies two fixes for property declaration inferences:

* #755: filters them in `updateAssignedTypesForReference ` to only apply when the target being assigned is the same class being inferred for (the `.parent` of the property declaration `node`)
* #756: filters them in `fixMissingPropertyAccesses` to not apply when the node already has the same name declared