### PR TITLE
Used getTypeAtLocationIfNotError for type retrievals

### DIFF
--- a/src/mutations/assignments.ts
+++ b/src/mutations/assignments.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 
 import { FileMutationsRequest } from "../mutators/fileMutator";
+import { getTypeAtLocationIfNotError } from "../shared/types";
 
 export interface AssignedTypeValue {
     /**
@@ -37,8 +38,10 @@ export const joinAssignedTypesByName = (request: FileMutationsRequest, assignedT
                 continue;
             }
 
-            const propertyType = request.services.program.getTypeChecker().getTypeAtLocation(relevantDeclaration);
-            assignedTypesByName.set(property.name, propertyType);
+            const propertyType = getTypeAtLocationIfNotError(request, relevantDeclaration);
+            if (propertyType !== undefined) {
+                assignedTypesByName.set(property.name, propertyType);
+            }
         }
     }
 

--- a/src/mutations/expansions/expansionMutations.ts
+++ b/src/mutations/expansions/expansionMutations.ts
@@ -12,6 +12,7 @@ import { addMissingTypesToType } from "./addMissingTypesToType";
 import { originalTypeHasIncompleteType } from "./eliminations";
 import { summarizeAllAssignedTypes, TypeSummariesByName } from "./summarization";
 import { isNodeWithType, PropertySignatureWithType } from "../../shared/nodeTypes";
+import { getTypeAtLocationIfNotError } from "../../shared/types";
 
 /**
  * Given an interface or type declaration and a set of later-assigned types,
@@ -36,8 +37,8 @@ export const createTypeExpansionMutation = (
         }
 
         // If the type matches an existing property in name but not in type, we'll add the new type in there
-        const originalPropertyType = request.services.program.getTypeChecker().getTypeAtLocation(originalProperty);
-        if (originalTypeHasIncompleteType(request, originalPropertyType, summary.types)) {
+        const originalPropertyType = getTypeAtLocationIfNotError(request, originalProperty);
+        if (originalPropertyType !== undefined && originalTypeHasIncompleteType(request, originalPropertyType, summary.types)) {
             incompleteTypes.set(name, { originalProperty, originalPropertyType, summary });
         }
     }

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/getGenericClassDetails.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/getGenericClassDetails.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { typeHasLocalTypeParameters } from "../../../../../shared/types";
+import { getTypeAtLocationIfNotError, typeHasLocalTypeParameters } from "../../../../../shared/types";
 import { FileMutationsRequest } from "../../../../fileMutator";
 
 import { VariableWithImplicitGeneric } from "./implicitGenericTypes";
@@ -36,11 +36,9 @@ export interface ParameterTypeNodeSummary {
 }
 
 export const getGenericClassDetails = (request: FileMutationsRequest, node: VariableWithImplicitGeneric) => {
-    const typeChecker = request.services.program.getTypeChecker();
-
     // Get the backing type of the variable's initializer
-    const initializerType = typeChecker.getTypeAtLocation(node.initializer);
-    const initializerSymbol = initializerType.getSymbol();
+    const initializerType = getTypeAtLocationIfNotError(request, node.initializer);
+    const initializerSymbol = initializerType?.getSymbol();
     if (initializerSymbol === undefined) {
         return undefined;
     }
@@ -52,6 +50,7 @@ export const getGenericClassDetails = (request: FileMutationsRequest, node: Vari
     }
 
     // Only care about types that have at least one (local?) type parameter
+    const typeChecker = request.services.program.getTypeChecker();
     const containerType = typeChecker.getDeclaredTypeOfSymbol(initializerSymbol);
     if (
         !typeHasLocalTypeParameters(containerType) ||

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
@@ -143,9 +143,8 @@ const collectMissingAssignedTypesOnChildClassNode = (
     }
 
     // We only care about this node if the instance it's referencing is (or generally is a subtype of) the child class
-    const typeChecker = request.services.program.getTypeChecker();
-    const expressionType = getTypeAtLocationIfNotError(typeChecker, parentPropertyAccess.expression);
-    if (expressionType === undefined || !typeChecker.isTypeAssignableTo(expressionType, childClassType)) {
+    const expressionType = getTypeAtLocationIfNotError(request, parentPropertyAccess.expression);
+    if (expressionType === undefined || !request.services.program.getTypeChecker().isTypeAssignableTo(expressionType, childClassType)) {
         return undefined;
     }
 
@@ -194,15 +193,17 @@ const getMissingAssignedType = (
     }
 
     // If the type parameter came with a default, ignore types already equivalent to it
-    const typeChecker = request.services.program.getTypeChecker();
-    if (defaultTypeParameterType !== undefined && typeChecker.isTypeAssignableTo(defaultTypeParameterType, assigningType)) {
+    if (
+        defaultTypeParameterType !== undefined &&
+        request.services.program.getTypeChecker().isTypeAssignableTo(defaultTypeParameterType, assigningType)
+    ) {
         return undefined;
     }
 
     // Nodes that reach here are either 'standalone' declarations (the full type) or members thereof...
     // For a full type, go through the normal hoops to figure out its name
     if (asStandaloneProperty) {
-        const standaloneType = getTypeAtLocationIfNotError(typeChecker, assigningNode);
+        const standaloneType = getTypeAtLocationIfNotError(request, assigningNode);
         return standaloneType === undefined ? undefined : createTypeName(request, standaloneType);
     }
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
@@ -4,6 +4,7 @@ import { createTypeName } from "../../../../mutations/aliasing/createTypeName";
 import { AssignedTypesByName, AssignedTypeValue, joinAssignedTypesByName } from "../../../../mutations/assignments";
 import { getStaticNameOfProperty } from "../../../../shared/names";
 import { isNodeAssigningBinaryExpression, isNodeWithinNode } from "../../../../shared/nodes";
+import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { FileMutationsRequest } from "../../../fileMutator";
 
 import { collectTypeParameterReferences } from "./collectTypeParameterReferences";
@@ -83,10 +84,13 @@ const collectMissingAssignedParameterTypes = (
 ) => {
     const knownNames = new Set<string>();
     const assignedTypeValues: AssignedTypeValue[] = [];
-    const typeChecker = request.services.program.getTypeChecker();
-    const childClassType = typeChecker.getTypeAtLocation(childClass);
+    const childClassType = getTypeAtLocationIfNotError(request, childClass);
+    if (childClassType === undefined) {
+        return knownNames;
+    }
+
     const defaultTypeParameterType =
-        baseTypeParameter.default === undefined ? undefined : typeChecker.getTypeAtLocation(baseTypeParameter.default);
+        baseTypeParameter.default === undefined ? undefined : getTypeAtLocationIfNotError(request, baseTypeParameter.default);
 
     for (const typeParameterReference of typeParameterReferences) {
         // For now, we only look at nodes whose usage is declared *within* the child class
@@ -140,8 +144,8 @@ const collectMissingAssignedTypesOnChildClassNode = (
 
     // We only care about this node if the instance it's referencing is (or generally is a subtype of) the child class
     const typeChecker = request.services.program.getTypeChecker();
-    const expressionType = typeChecker.getTypeAtLocation(parentPropertyAccess.expression);
-    if (!typeChecker.isTypeAssignableTo(expressionType, childClassType)) {
+    const expressionType = getTypeAtLocationIfNotError(typeChecker, parentPropertyAccess.expression);
+    if (expressionType === undefined || !typeChecker.isTypeAssignableTo(expressionType, childClassType)) {
         return undefined;
     }
 
@@ -184,21 +188,27 @@ const getMissingAssignedType = (
     assigningNode: ts.Node,
     asStandaloneProperty: boolean,
 ) => {
-    const typeChecker = request.services.program.getTypeChecker();
-    const assigningType = typeChecker.getTypeAtLocation(assigningNode);
+    const assigningType = getTypeAtLocationIfNotError(request, assigningNode);
+    if (assigningType === undefined) {
+        return undefined;
+    }
 
     // If the type parameter came with a default, ignore types already equivalent to it
+    const typeChecker = request.services.program.getTypeChecker();
     if (defaultTypeParameterType !== undefined && typeChecker.isTypeAssignableTo(defaultTypeParameterType, assigningType)) {
         return undefined;
     }
 
     // Nodes that reach here are either 'standalone' declarations (the full type) or members thereof...
-    return asStandaloneProperty
-        ? // For a full type, go through the normal hoops to figure out its name
-          createTypeName(request, typeChecker.getTypeAtLocation(assigningNode))
-        : // For a property, just grab the basic name and type, so we can join them all together later
-          {
-              name: getStaticNameOfProperty(assigningNode),
-              type: assigningType,
-          };
+    // For a full type, go through the normal hoops to figure out its name
+    if (asStandaloneProperty) {
+        const standaloneType = getTypeAtLocationIfNotError(typeChecker, assigningNode);
+        return standaloneType === undefined ? undefined : createTypeName(request, standaloneType);
+    }
+
+    // For a property, just grab the basic name and type, so we can join them all together later
+    return {
+        name: getStaticNameOfProperty(assigningNode),
+        type: assigningType,
+    };
 };

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/index.ts
@@ -3,6 +3,7 @@ import * as ts from "typescript";
 
 import { joinAssignedTypesByName } from "../../../../mutations/assignments";
 import { createTypeExpansionMutation } from "../../../../mutations/expansions/expansionMutations";
+import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
 
@@ -23,7 +24,10 @@ const visitInterfaceOrTypeLiteral = (node: InterfaceOrTypeLiteral, request: File
     }
 
     // Given all those generic references, find all the types being assigned to those nodes
-    const originalType = request.services.program.getTypeChecker().getTypeAtLocation(node);
+    const originalType = getTypeAtLocationIfNotError(request, node);
+    if (originalType === undefined) {
+        return undefined;
+    }
     const valuesAssignedToReferenceNodes = expandValuesAssignedToReferenceNodes(request, originalType, genericReferenceNodes);
     if (valuesAssignedToReferenceNodes.length === 0) {
         return undefined;

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 
 import { AssignedTypesByName } from "../../../../../mutations/assignments";
 import { getStaticNameOfProperty } from "../../../../../shared/names";
+import { getTypeAtLocationIfNotError } from "../../../../../shared/types";
 import { FileMutationsRequest } from "../../../../fileMutator";
 import { ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
@@ -65,7 +66,10 @@ const updateAssignedTypesForReference = (
         }
 
         // TypeScript stores the type of the property's value on the property itself
-        assignedTypes.set(name, request.services.program.getTypeChecker().getTypeAtLocation(property));
+        const propertyType = getTypeAtLocationIfNotError(request, property);
+        if (propertyType !== undefined) {
+            assignedTypes.set(name, propertyType);
+        }
     }
 
     componentAssignedTypes.push(assignedTypes);

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentPropsNode.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 
 import { getClassExtendsType } from "../../../../../shared/nodes";
+import { getTypeAtLocationIfNotError } from "../../../../../shared/types";
 import { FileMutationsRequest } from "../../../../fileMutator";
 import { ReactClassComponentNode, ReactComponentNode, ReactFunctionalComponentNode } from "../reactFiltering/isReactComponentNode";
 
@@ -22,8 +23,8 @@ const getClassComponentPropsNode = (request: FileMutationsRequest, node: ReactCl
     }
 
     const [rawPropsNode] = extendsType.typeArguments;
-    const propsNodeType = request.services.program.getTypeChecker().getTypeAtLocation(rawPropsNode);
-    const propsNodeSymbol = propsNodeType.getSymbol();
+    const propsNodeType = getTypeAtLocationIfNotError(request, rawPropsNode);
+    const propsNodeSymbol = propsNodeType?.getSymbol();
     if (propsNodeSymbol === undefined) {
         return undefined;
     }
@@ -44,8 +45,8 @@ const getFunctionalComponentPropsNode = (
     }
 
     const [parameter] = parameters;
-    const type = request.services.program.getTypeChecker().getTypeAtLocation(parameter);
-    const symbol = type.getSymbol();
+    const type = getTypeAtLocationIfNotError(request, parameter);
+    const symbol = type?.getSymbol();
     if (symbol === undefined || symbol.declarations.length === 0) {
         return undefined;
     }

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
@@ -3,6 +3,7 @@ import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
 import { createTypeAdditionMutation } from "../../../../mutations/creators";
+import { isNotUndefined } from "../../../../shared/arrays";
 import { FunctionLikeDeclarationWithType, isNodeWithType } from "../../../../shared/nodeTypes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
@@ -25,7 +26,9 @@ const visitFunctionWithBody = (node: FunctionLikeDeclarationWithType, request: F
     }
 
     // Collect types of nodes returned by the function
-    const returnedTypes = collectReturningNodeExpressions(node).map(request.services.program.getTypeChecker().getTypeAtLocation);
+    const returnedTypes = collectReturningNodeExpressions(node)
+        .map((node) => getTypeAtLocationIfNotError(request, node))
+        .filter(isNotUndefined);
 
     // Add later-returned types to the node's type declaration if necessary
     return createTypeAdditionMutation(request, node, declaredType, returnedTypes);

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
@@ -4,6 +4,7 @@ import * as ts from "typescript";
 
 import { createTypeAdditionMutation } from "../../../../mutations/creators";
 import { FunctionLikeDeclarationWithType, isNodeWithType } from "../../../../shared/nodeTypes";
+import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
 import { collectReturningNodeExpressions } from "../../fixStrictNonNullAssertions/fixStrictNonNullAssertionReturnTypes/collectReturningNodeExpressions";
@@ -18,7 +19,10 @@ const isNodeVisitableFunctionLikeDeclaration = (node: ts.Node): node is Function
 
 const visitFunctionWithBody = (node: FunctionLikeDeclarationWithType, request: FileMutationsRequest) => {
     // Collect the type initially declared as returned
-    const declaredType = request.services.program.getTypeChecker().getTypeAtLocation(node.type);
+    const declaredType = getTypeAtLocationIfNotError(request, node.type);
+    if (declaredType === undefined) {
+        return undefined;
+    }
 
     // Collect types of nodes returned by the function
     const returnedTypes = collectReturningNodeExpressions(node).map(request.services.program.getTypeChecker().getTypeAtLocation);

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
@@ -21,10 +21,8 @@ const isVisitableCallExpression = (node: ts.Node): node is ts.CallExpression =>
     node.arguments.length !== 0;
 
 const visitCallExpression = (node: ts.CallExpression, request: FileMutationsRequest): IMultipleMutations | undefined => {
-    const typeChecker = request.services.program.getTypeChecker();
-
     // Collect the declared type of the function-like being called
-    const functionLikeValueDeclaration = getValueDeclarationOfFunction(typeChecker, node.expression);
+    const functionLikeValueDeclaration = getValueDeclarationOfFunction(request, node.expression);
     if (functionLikeValueDeclaration === undefined) {
         return undefined;
     }

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
@@ -7,6 +7,7 @@ import { createNonNullAssertion } from "../../../../mutations/typeMutating/creat
 import { getValueDeclarationOfFunction } from "../../../../shared/functionTypes";
 import { getParentOfKind, getVariableInitializerForExpression } from "../../../../shared/nodes";
 import { isNullOrUndefinedMissingBetween } from "../../../../shared/nodeTypes";
+import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
 
@@ -43,20 +44,19 @@ const collectArgumentMutations = (
 ): ReadonlyArray<IMutation> => {
     const mutations: IMutation[] = [];
     const visitableArguments = Math.min(callingNode.arguments.length, functionLikeValueDeclaration.parameters.length);
-    const typeChecker = request.services.program.getTypeChecker();
 
     // Check the types of each argument being passed in against the declared parameter type
     for (let i = 0; i < visitableArguments; i += 1) {
         // We can ignore parameters that are 'any'
-        const typeOfParameter = typeChecker.getTypeAtLocation(functionLikeValueDeclaration.parameters[i]);
-        if (isTypeFlagSetRecursively(typeOfParameter, ts.TypeFlags.Any)) {
+        const typeOfParameter = getTypeAtLocationIfNotError(request, functionLikeValueDeclaration.parameters[i]);
+        if (typeOfParameter === undefined || isTypeFlagSetRecursively(typeOfParameter, ts.TypeFlags.Any)) {
             continue;
         }
 
-        const typeOfArgument = typeChecker.getTypeAtLocation(callingNode.arguments[i]);
+        const typeOfArgument = getTypeAtLocationIfNotError(request, callingNode.arguments[i]);
 
         // If either null or undefined is missing in the argument, we'll need a ! mutation
-        if (isNullOrUndefinedMissingBetween(typeOfArgument, typeOfParameter)) {
+        if (typeOfArgument !== undefined && isNullOrUndefinedMissingBetween(typeOfArgument, typeOfParameter)) {
             mutations.push(collectArgumentMutation(request, callingNode.arguments[i]));
         }
     }

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionObjectLiterals/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionObjectLiterals/index.ts
@@ -19,8 +19,7 @@ export const fixStrictNonNullAssertionObjectLiterals: FileMutator = (request: Fi
 
 const getStrictPropertyFix = (request: FileMutationsRequest, node: ts.ObjectLiteralExpression): IMutation | undefined => {
     // Find the object type the node's properties are being assigned into
-    const typeChecker = request.services.program.getTypeChecker();
-    const assignedType = getManuallyAssignedTypeOfNode(typeChecker, node);
+    const assignedType = getManuallyAssignedTypeOfNode(request, node);
     if (assignedType === undefined) {
         return undefined;
     }
@@ -41,10 +40,13 @@ const getStrictPropertyFix = (request: FileMutationsRequest, node: ts.ObjectLite
             }
 
             // We'll mutate properties that are declared as non-nullable but assigned a nullable value
-            const propertyType = getTypeAtLocationIfNotError(typeChecker, property);
+            const propertyType = getTypeAtLocationIfNotError(request, property);
             return (
                 propertyType !== undefined &&
-                isNullOrUndefinedMissingBetween(propertyType, typeChecker.getDeclaredTypeOfSymbol(assignedProperty))
+                isNullOrUndefinedMissingBetween(
+                    propertyType,
+                    request.services.program.getTypeChecker().getDeclaredTypeOfSymbol(assignedProperty),
+                )
             );
         })
         // Convert each of those properties into an assertion mutation

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
@@ -3,6 +3,7 @@ import * as ts from "typescript";
 
 import { isTypeFlagSetRecursively } from "../../../../mutations/collecting/flags";
 import { createNonNullAssertion } from "../../../../mutations/typeMutating/createNonNullAssertion";
+import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
 
@@ -16,10 +17,10 @@ export const fixStrictNonNullAssertionPropertyAccesses: FileMutator = (request: 
 
 const getStrictPropertyAccessFix = (request: FileMutationsRequest, node: ts.PropertyAccessExpression): IMutation | undefined => {
     // Grab the type of the property being accessed by name
-    const expressionType = request.services.program.getTypeChecker().getTypeAtLocation(node.expression);
+    const expressionType = getTypeAtLocationIfNotError(request, node.expression);
 
     // If the property's type cannot be null or undefined, rejoice! Nothing to do.
-    if (!isTypeFlagSetRecursively(expressionType, ts.TypeFlags.Null | ts.TypeFlags.Undefined)) {
+    if (expressionType === undefined || !isTypeFlagSetRecursively(expressionType, ts.TypeFlags.Null | ts.TypeFlags.Undefined)) {
         return undefined;
     }
 

--- a/src/shared/assignments.ts
+++ b/src/shared/assignments.ts
@@ -1,5 +1,6 @@
 import * as ts from "typescript";
 import { getValueDeclarationOfFunction } from "./functionTypes";
+import { getTypeAtLocationIfNotError } from "./types";
 
 /**
  * Given a node passed to a location with a declared, known type,
@@ -51,7 +52,7 @@ const getAssignedTypeOfParameter = (typeChecker: ts.TypeChecker, node: ts.Expres
         return undefined;
     }
 
-    return typeChecker.getTypeAtLocation(functionLikeValueDeclaration.parameters[argumentIndex]);
+    return getTypeAtLocationIfNotError(typeChecker, functionLikeValueDeclaration.parameters[argumentIndex]);
 };
 
 const getAssignedTypeOfVariable = (typeChecker: ts.TypeChecker, node: ts.VariableDeclaration) => {

--- a/src/shared/assignments.ts
+++ b/src/shared/assignments.ts
@@ -1,4 +1,5 @@
 import * as ts from "typescript";
+import { FileMutationsRequest } from "../mutators/fileMutator";
 import { getValueDeclarationOfFunction } from "./functionTypes";
 import { getTypeAtLocationIfNotError } from "./types";
 
@@ -25,23 +26,23 @@ import { getTypeAtLocationIfNotError } from "./types";
  *             // ^
  * ```
  */
-export const getManuallyAssignedTypeOfNode = (typeChecker: ts.TypeChecker, node: ts.Node) => {
+export const getManuallyAssignedTypeOfNode = (request: FileMutationsRequest, node: ts.Node) => {
     const { parent } = node;
 
     if (ts.isCallExpression(parent)) {
-        return getAssignedTypeOfParameter(typeChecker, node as ts.Expression, parent);
+        return getAssignedTypeOfParameter(request, node as ts.Expression, parent);
     }
 
     if (ts.isVariableDeclaration(parent)) {
-        return getAssignedTypeOfVariable(typeChecker, parent);
+        return getAssignedTypeOfVariable(request, parent);
     }
 
     return undefined;
 };
 
-const getAssignedTypeOfParameter = (typeChecker: ts.TypeChecker, node: ts.Expression, parent: ts.CallExpression) => {
+const getAssignedTypeOfParameter = (request: FileMutationsRequest, node: ts.Expression, parent: ts.CallExpression) => {
     // Collect the declared type of the function-like being called
-    const functionLikeValueDeclaration = getValueDeclarationOfFunction(typeChecker, parent.expression);
+    const functionLikeValueDeclaration = getValueDeclarationOfFunction(request, parent.expression);
     if (functionLikeValueDeclaration === undefined) {
         return undefined;
     }
@@ -52,13 +53,13 @@ const getAssignedTypeOfParameter = (typeChecker: ts.TypeChecker, node: ts.Expres
         return undefined;
     }
 
-    return getTypeAtLocationIfNotError(typeChecker, functionLikeValueDeclaration.parameters[argumentIndex]);
+    return getTypeAtLocationIfNotError(request, functionLikeValueDeclaration.parameters[argumentIndex]);
 };
 
-const getAssignedTypeOfVariable = (typeChecker: ts.TypeChecker, node: ts.VariableDeclaration) => {
+const getAssignedTypeOfVariable = (request: FileMutationsRequest, node: ts.VariableDeclaration) => {
     if (node.type === undefined) {
         return undefined;
     }
 
-    return typeChecker.getTypeFromTypeNode(node.type);
+    return request.services.program.getTypeChecker().getTypeFromTypeNode(node.type);
 };

--- a/src/shared/functionTypes.ts
+++ b/src/shared/functionTypes.ts
@@ -1,12 +1,14 @@
 import * as ts from "typescript";
 import * as tsutils from "tsutils";
+
+import { FileMutationsRequest } from "../mutators/fileMutator";
 import { getValueDeclarationOfType } from "./nodeTypes";
 
 /**
  * @returns Declared type of a function-like expression.
  */
-export const getValueDeclarationOfFunction = (typeChecker: ts.TypeChecker, node: ts.Expression) => {
-    const functionLikeValueDeclaration = getValueDeclarationOfType(typeChecker, node);
+export const getValueDeclarationOfFunction = (request: FileMutationsRequest, node: ts.Expression) => {
+    const functionLikeValueDeclaration = getValueDeclarationOfType(request, node);
     if (functionLikeValueDeclaration === undefined || !tsutils.isFunctionWithBody(functionLikeValueDeclaration)) {
         return undefined;
     }

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 
 import { isTypeFlagSetRecursively } from "../mutations/collecting/flags";
+import { FileMutationsRequest } from "../mutators/fileMutator";
 import { getTypeAtLocationIfNotError } from "./types";
 
 export type NodeSelector<TNode extends ts.Node> = (node: ts.Node) => node is TNode;
@@ -69,10 +70,10 @@ export const isNodeWithDefinedTypeParameters = (node: ts.Node): node is NodeWith
     return "typeParameters" in node;
 };
 
-export const getValueDeclarationOfType = (typeChecker: ts.TypeChecker, node: ts.Node): ts.Node | undefined => {
+export const getValueDeclarationOfType = (request: FileMutationsRequest, node: ts.Node): ts.Node | undefined => {
     // Try getting the symbol at the location, which sometimes only works in the latter form
-    const nodeType = getTypeAtLocationIfNotError(typeChecker, node);
-    const symbol = nodeType?.getSymbol() ?? typeChecker.getSymbolAtLocation(node);
+    const nodeType = getTypeAtLocationIfNotError(request, node);
+    const symbol = nodeType?.getSymbol() ?? request.services.program.getTypeChecker().getSymbolAtLocation(node);
 
     if (symbol === undefined) {
         return undefined;

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 import { isTypeFlagSetRecursively } from "../mutations/collecting/flags";
-import { isIntrisinicNameTypeNode } from "./typeNodes";
+import { getTypeAtLocationIfNotError } from "./types";
 
 export type NodeSelector<TNode extends ts.Node> = (node: ts.Node) => node is TNode;
 
@@ -71,12 +71,8 @@ export const isNodeWithDefinedTypeParameters = (node: ts.Node): node is NodeWith
 
 export const getValueDeclarationOfType = (typeChecker: ts.TypeChecker, node: ts.Node): ts.Node | undefined => {
     // Try getting the symbol at the location, which sometimes only works in the latter form
-    const nodeType = typeChecker.getTypeAtLocation(node);
-    let symbol = nodeType.getSymbol();
-
-    if (symbol === undefined) {
-        symbol = typeChecker.getSymbolAtLocation(node);
-    }
+    const nodeType = getTypeAtLocationIfNotError(typeChecker, node);
+    const symbol = nodeType?.getSymbol() ?? typeChecker.getSymbolAtLocation(node);
 
     if (symbol === undefined) {
         return undefined;

--- a/src/shared/nodes.ts
+++ b/src/shared/nodes.ts
@@ -69,8 +69,7 @@ export const getVariableInitializerForExpression = (
         return undefined;
     }
 
-    const typeChecker = request.services.program.getTypeChecker();
-    const valueDeclaration = getValueDeclarationOfType(typeChecker, expression);
+    const valueDeclaration = getValueDeclarationOfType(request, expression);
     if (
         valueDeclaration === undefined ||
         (parentFunctionLike !== undefined && !isNodeWithinNode(request.sourceFile, valueDeclaration, parentFunctionLike))

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,6 @@
 import * as ts from "typescript";
+import { FileMutationsRequest } from "../mutators/fileMutator";
+import { isIntrisinicNameTypeNode } from "./typeNodes";
 
 /**
  * @returns Whether the type has `localTypeParameters`, such as the built-in Map and Array definitions.
@@ -18,4 +20,20 @@ export const isTypeBuiltIn = (type: ts.Type) => {
     const sourceFile = symbol.valueDeclaration.getSourceFile();
 
     return sourceFile.hasNoDefaultLib && sourceFile.isDeclarationFile && sourceFile.fileName.includes("node_modules/typescript/lib/");
+};
+
+export const getTypeAtLocationIfNotError = (
+    requestOrTypeChecker: FileMutationsRequest | ts.TypeChecker,
+    node: ts.Node | undefined,
+): ts.Type | undefined => {
+    if (node === undefined) {
+        return undefined;
+    }
+
+    const type =
+        "getTypeAtLocation" in requestOrTypeChecker
+            ? requestOrTypeChecker.getTypeAtLocation(node)
+            : requestOrTypeChecker.services.program.getTypeChecker().getTypeAtLocation(node);
+
+    return isIntrisinicNameTypeNode(type) && type.intrinsicName === "error" ? undefined : type;
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,18 +22,12 @@ export const isTypeBuiltIn = (type: ts.Type) => {
     return sourceFile.hasNoDefaultLib && sourceFile.isDeclarationFile && sourceFile.fileName.includes("node_modules/typescript/lib/");
 };
 
-export const getTypeAtLocationIfNotError = (
-    requestOrTypeChecker: FileMutationsRequest | ts.TypeChecker,
-    node: ts.Node | undefined,
-): ts.Type | undefined => {
+export const getTypeAtLocationIfNotError = (request: FileMutationsRequest, node: ts.Node | undefined): ts.Type | undefined => {
     if (node === undefined) {
         return undefined;
     }
 
-    const type =
-        "getTypeAtLocation" in requestOrTypeChecker
-            ? requestOrTypeChecker.getTypeAtLocation(node)
-            : requestOrTypeChecker.services.program.getTypeChecker().getTypeAtLocation(node);
+    const type = request.services.program.getTypeChecker().getTypeAtLocation(node);
 
     return isIntrisinicNameTypeNode(type) && type.intrinsicName === "error" ? undefined : type;
 };

--- a/test/cases/fixes/incompleteTypes/variableTypes/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/variableTypes/expected.tsx
@@ -1,29 +1,31 @@
+import * as React from 'react';
+
 (function () {
     // Primitives
 
     let givenUndefined = "";
     givenUndefined = undefined;
 
-    let givenUndefinedAsString: string = "";
+    let givenUndefinedAsString: string | undefined = "";
     givenUndefinedAsString = undefined;
 
-    let givenUndefinedHasNull: string | null = "";
+    let givenUndefinedHasNull: string | null | undefined = "";
     givenUndefinedHasNull = undefined;
 
-    let givenNullAndUndefinedHasNull: string | null = "";
+    let givenNullAndUndefinedHasNull: string | null | undefined = "";
     givenNullAndUndefinedHasNull = null;
     givenNullAndUndefinedHasNull = undefined;
 
     let givenNull = "";
     givenNull = null;
 
-    let givenNullAsString: string = "";
+    let givenNullAsString: string | null = "";
     givenNullAsString = null;
 
-    let givenNullHasUndefined: string | undefined = "";
+    let givenNullHasUndefined: string | undefined | null = "";
     givenNullHasUndefined = null;
 
-    let givenNullAndUndefinedHasUndefined: string | undefined = "";
+    let givenNullAndUndefinedHasUndefined: string | undefined | null = "";
     givenNullAndUndefinedHasUndefined = null;
     givenNullHasUndefined = undefined;
 
@@ -39,15 +41,15 @@
     let givenStringHasUndefined: string | undefined = "";
     givenStringHasNull = "";
 
-    let setToUndefined: string = undefined;
+    let setToUndefined: string | undefined = undefined;
 
-    let setToUndefinedHasNull: string | null = undefined;
+    let setToUndefinedHasNull: string | null | undefined = undefined;
 
-    let setToNull: string = null;
+    let setToNull: string | null = null;
 
     let setToNullAsNull = null;
 
-    let setToNullHasUndefined: string | undefined = null;
+    let setToNullHasUndefined: string | undefined | null = null;
 
     let setToString = "";
 
@@ -59,12 +61,12 @@
 
     // Any
 
-    let startsAnyWithString: any = "";
+    let startsAnyWithString: any | string = "";
 
-    let startsAnyGivenString: any;
+    let startsAnyGivenString: any | string;
     startsAnyGivenString = "";
 
-    let startsAnyWithStringGivenString: any = "";
+    let startsAnyWithStringGivenString: any | string = "";
     startsAnyWithStringGivenString = "";
 
     let startsStringWithAny: string = {} as any;
@@ -113,7 +115,7 @@
     let eitherClassNeedsUnionImplicit = new SampleClassOne();
     eitherClassNeedsUnionImplicit = new SampleClassTwo();
 
-    let eitherClassNeedsUnionExplicit: SampleClassOne = new SampleClassOne();
+    let eitherClassNeedsUnionExplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
     eitherClassNeedsUnionExplicit = new SampleClassTwo();
 
     let eitherClassNeedsUnionExplicitInterface: SampleInterface = new SampleClassOne();
@@ -123,19 +125,19 @@
     eitherClassNeedsNullImplicit = new SampleClassTwo();
     eitherClassNeedsNullImplicit = null;
 
-    let eitherClassNeedsNullAndClassExplicit: SampleClassOne | null = new SampleClassOne();
+    let eitherClassNeedsNullAndClassExplicit: SampleClassOne | null | SampleClassTwo = new SampleClassOne();
     eitherClassNeedsNullAndClassExplicit = new SampleClassTwo();
     eitherClassNeedsNullAndClassExplicit = null;
 
-    let eitherClassNeedsUndefinedExplicit: SampleClassOne = new SampleClassOne();
+    let eitherClassNeedsUndefinedExplicit: SampleClassOne | SampleClassTwo | undefined = new SampleClassOne();
     eitherClassNeedsUndefinedExplicit = new SampleClassTwo();
     eitherClassNeedsUndefinedExplicit = undefined;
 
-    let eitherClassNeedsUndefinedExplicitInterface: SampleInterface = new SampleClassOne();
+    let eitherClassNeedsUndefinedExplicitInterface: SampleInterface | undefined = new SampleClassOne();
     eitherClassNeedsUndefinedExplicitInterface = new SampleClassTwo();
     eitherClassNeedsUndefinedExplicitInterface = undefined;
 
-    let eitherClassNeedsUndefinedAndClassExplicit: SampleClassOne | undefined = new SampleClassOne();
+    let eitherClassNeedsUndefinedAndClassExplicit: SampleClassOne | undefined | SampleClassTwo = new SampleClassOne();
     eitherClassNeedsUndefinedAndClassExplicit = new SampleClassTwo();
     eitherClassNeedsUndefinedAndClassExplicit = undefined;
 
@@ -171,10 +173,22 @@
 
     // Functions
 
-    let returnsString: Function;
+    let returnsString: (() => string);
     returnsString = () => "";
 
-    let returnsStringOrNumber: Function;
+    let returnsStringOrNumber: (() => string) | (() => number);
     returnsStringOrNumber = () => "";
     returnsStringOrNumber = () => 0;
+
+    // Predeclared functions (React FCs)
+    
+    interface MyComponentProps {
+        text: string;
+    }
+
+    const MyComponent: React.FC<MyComponentProps> = ({
+        text 
+    }) => {
+        return <span>{text}</span>;
+    }
 })();

--- a/test/cases/fixes/incompleteTypes/variableTypes/original.tsx
+++ b/test/cases/fixes/incompleteTypes/variableTypes/original.tsx
@@ -1,29 +1,31 @@
+import * as React from 'react';
+
 (function () {
     // Primitives
 
     let givenUndefined = "";
     givenUndefined = undefined;
 
-    let givenUndefinedAsString: string | undefined = "";
+    let givenUndefinedAsString: string = "";
     givenUndefinedAsString = undefined;
 
-    let givenUndefinedHasNull: string | null | undefined = "";
+    let givenUndefinedHasNull: string | null = "";
     givenUndefinedHasNull = undefined;
 
-    let givenNullAndUndefinedHasNull: string | null | undefined = "";
+    let givenNullAndUndefinedHasNull: string | null = "";
     givenNullAndUndefinedHasNull = null;
     givenNullAndUndefinedHasNull = undefined;
 
     let givenNull = "";
     givenNull = null;
 
-    let givenNullAsString: string | null = "";
+    let givenNullAsString: string = "";
     givenNullAsString = null;
 
-    let givenNullHasUndefined: string | undefined | null = "";
+    let givenNullHasUndefined: string | undefined = "";
     givenNullHasUndefined = null;
 
-    let givenNullAndUndefinedHasUndefined: string | undefined | null = "";
+    let givenNullAndUndefinedHasUndefined: string | undefined = "";
     givenNullAndUndefinedHasUndefined = null;
     givenNullHasUndefined = undefined;
 
@@ -39,15 +41,15 @@
     let givenStringHasUndefined: string | undefined = "";
     givenStringHasNull = "";
 
-    let setToUndefined: string | undefined = undefined;
+    let setToUndefined: string = undefined;
 
-    let setToUndefinedHasNull: string | null | undefined = undefined;
+    let setToUndefinedHasNull: string | null = undefined;
 
-    let setToNull: string | null = null;
+    let setToNull: string = null;
 
     let setToNullAsNull = null;
 
-    let setToNullHasUndefined: string | undefined | null = null;
+    let setToNullHasUndefined: string | undefined = null;
 
     let setToString = "";
 
@@ -59,12 +61,12 @@
 
     // Any
 
-    let startsAnyWithString: any | string = "";
+    let startsAnyWithString: any = "";
 
-    let startsAnyGivenString: any | string;
+    let startsAnyGivenString: any;
     startsAnyGivenString = "";
 
-    let startsAnyWithStringGivenString: any | string = "";
+    let startsAnyWithStringGivenString: any = "";
     startsAnyWithStringGivenString = "";
 
     let startsStringWithAny: string = {} as any;
@@ -113,7 +115,7 @@
     let eitherClassNeedsUnionImplicit = new SampleClassOne();
     eitherClassNeedsUnionImplicit = new SampleClassTwo();
 
-    let eitherClassNeedsUnionExplicit: SampleClassOne | SampleClassTwo = new SampleClassOne();
+    let eitherClassNeedsUnionExplicit: SampleClassOne = new SampleClassOne();
     eitherClassNeedsUnionExplicit = new SampleClassTwo();
 
     let eitherClassNeedsUnionExplicitInterface: SampleInterface = new SampleClassOne();
@@ -123,19 +125,19 @@
     eitherClassNeedsNullImplicit = new SampleClassTwo();
     eitherClassNeedsNullImplicit = null;
 
-    let eitherClassNeedsNullAndClassExplicit: SampleClassOne | null | SampleClassTwo = new SampleClassOne();
+    let eitherClassNeedsNullAndClassExplicit: SampleClassOne | null = new SampleClassOne();
     eitherClassNeedsNullAndClassExplicit = new SampleClassTwo();
     eitherClassNeedsNullAndClassExplicit = null;
 
-    let eitherClassNeedsUndefinedExplicit: SampleClassOne | SampleClassTwo | undefined = new SampleClassOne();
+    let eitherClassNeedsUndefinedExplicit: SampleClassOne = new SampleClassOne();
     eitherClassNeedsUndefinedExplicit = new SampleClassTwo();
     eitherClassNeedsUndefinedExplicit = undefined;
 
-    let eitherClassNeedsUndefinedExplicitInterface: SampleInterface | undefined = new SampleClassOne();
+    let eitherClassNeedsUndefinedExplicitInterface: SampleInterface = new SampleClassOne();
     eitherClassNeedsUndefinedExplicitInterface = new SampleClassTwo();
     eitherClassNeedsUndefinedExplicitInterface = undefined;
 
-    let eitherClassNeedsUndefinedAndClassExplicit: SampleClassOne | undefined | SampleClassTwo = new SampleClassOne();
+    let eitherClassNeedsUndefinedAndClassExplicit: SampleClassOne | undefined = new SampleClassOne();
     eitherClassNeedsUndefinedAndClassExplicit = new SampleClassTwo();
     eitherClassNeedsUndefinedAndClassExplicit = undefined;
 
@@ -171,10 +173,22 @@
 
     // Functions
 
-    let returnsString: (() => string);
+    let returnsString: Function;
     returnsString = () => "";
 
-    let returnsStringOrNumber: (() => string) | (() => number);
+    let returnsStringOrNumber: Function;
     returnsStringOrNumber = () => "";
     returnsStringOrNumber = () => 0;
+
+    // Predeclared functions (React FCs)
+    
+    interface MyComponentProps {
+        text: string;
+    }
+
+    const MyComponent: React.FC<MyComponentProps> = ({
+        text 
+    }) => {
+        return <span>{text}</span>;
+    }
 })();

--- a/test/cases/fixes/incompleteTypes/variableTypes/tsconfig.json
+++ b/test/cases/fixes/incompleteTypes/variableTypes/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "files": ["actual.ts"]
+    "files": ["actual.tsx"]
 }


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #758
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Introduces a `getTypeAtLocationIfNotError` that returns `undefined` if the result of a type checker's `getTypeAtLocation` has the `error` type.