### PR TITLE
Added Function usage inferences for React props

### DIFF
--- a/src/mutations/assignments.ts
+++ b/src/mutations/assignments.ts
@@ -15,6 +15,9 @@ export interface AssignedTypeValue {
     type: ts.Type;
 }
 
+/**
+ * For each new member of a type, a string or type representation of what it is known to be assigned.
+ */
 export type AssignedTypesByName = Map<string, ts.Type>;
 
 /**

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/collectGenericNodeReferences.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/collectGenericNodeReferences.ts
@@ -6,7 +6,7 @@ import {
     isNodeWithDefinedTypeParameters,
     isNodeWithIdentifierName,
 } from "../../../../shared/nodeTypes";
-import { isTypeArgumentsTypeNode } from "../../../../shared/typeNodes";
+import { isTypeArgumentsType } from "../../../../shared/typeNodes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { FileMutationsRequest } from "../../../fileMutator";
 
@@ -211,7 +211,7 @@ const expressionRefersToOriginalType = (
     // If the expression node's type already has type arguments, do they match the original type?
     // This is more likely with classes that are instantiated with a type
     // This can go wrong easily: e.g. with multiple type arguments that have intermixed usages
-    if (isTypeArgumentsTypeNode(expressionNodeType) && expressionNodeType.typeArguments?.includes(originalType)) {
+    if (isTypeArgumentsType(expressionNodeType) && expressionNodeType.typeArguments?.includes(originalType)) {
         return true;
     }
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/collectAllFunctionCallTypes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/collectAllFunctionCallTypes.ts
@@ -1,0 +1,94 @@
+import * as ts from "typescript";
+import { isTypeElementWithStaticName, TypeElementWithStaticName } from "../../../../../shared/nodeTypes";
+import { getTypeAtLocationIfNotError } from "../../../../../shared/types";
+
+import { FileMutationsRequest } from "../../../../fileMutator";
+import { ReactComponentPropsNode } from "../getComponentPropsNode";
+
+export type FunctionCallType = {
+    parameters?: (ts.Type | undefined)[];
+    returnValue?: ts.Type;
+};
+
+export const collectAllFunctionCallTypes = (request: FileMutationsRequest, propsNode: ReactComponentPropsNode) => {
+    const allFunctionCallTypes = new Map<TypeElementWithStaticName, FunctionCallType[]>();
+
+    for (const member of propsNode.members) {
+        collectFunctionCallsTypes(request, member, allFunctionCallTypes);
+    }
+
+    return allFunctionCallTypes;
+};
+
+const collectFunctionCallsTypes = (
+    request: FileMutationsRequest,
+    member: ts.TypeElement,
+    allFunctionCallTypes: Map<TypeElementWithStaticName, FunctionCallType[]>,
+) => {
+    if (!isTypeElementWithStaticName(member)) {
+        return;
+    }
+
+    // Find all references to the name of the type
+    const references = request.fileInfoCache.getNodeReferencesAsNodes(member.name);
+    if (references === undefined) {
+        return;
+    }
+
+    const functionCallTypes: FunctionCallType[] = [];
+
+    // For each reference, try to infer the type from its usage...
+    for (const reference of references) {
+        // (except for the original member we're looking around)
+        if (reference === member) {
+            continue;
+        }
+
+        const call = getCallForReference(reference);
+        if (call !== undefined) {
+            collectFunctionCallTypes(request, functionCallTypes, call);
+        }
+    }
+
+    allFunctionCallTypes.set(member, functionCallTypes);
+};
+
+const getCallForReference = (reference: ts.Node) => {
+    // Case: class-style (e.g. 'this.props.key') or object style 'props.key'
+    if (ts.isPropertyAccessExpression(reference.parent)) {
+        reference = reference.parent;
+    }
+
+    return ts.isCallExpression(reference.parent) ? reference.parent : undefined;
+};
+
+const collectFunctionCallTypes = (request: FileMutationsRequest, functionCallTypes: FunctionCallType[], call: ts.CallExpression) => {
+    // Case: the return value is directly passed to a function
+    if ((ts.isCallExpression(call.parent) || ts.isNewExpression(call.parent)) && call.parent.arguments !== undefined) {
+        // Find the corresponding type for the function that's taking in the prop function call
+        const parentCallType = getTypeAtLocationIfNotError(request, call.parent.expression);
+        if (parentCallType !== undefined) {
+            // Get the signatures for that parent call
+            const parentSignatures = ts.isCallExpression(call.parent)
+                ? parentCallType.getCallSignatures()
+                : parentCallType.getConstructSignatures();
+            const parameterIndex = call.parent.arguments.indexOf(call);
+
+            // For each signature, infer the paramter type that the prop function's return is being passed to
+            for (const parentSignature of parentSignatures) {
+                functionCallTypes.push({
+                    returnValue: request.services.program
+                        .getTypeChecker()
+                        .getTypeOfSymbolAtLocation(parentSignature.parameters[parameterIndex], call.parent.arguments[parameterIndex]),
+                });
+            }
+        }
+    }
+
+    // If the prop function is passed arguments, infer types from them
+    if (call.arguments.length !== 0) {
+        functionCallTypes.push({
+            parameters: call.arguments.map((callArgument) => getTypeAtLocationIfNotError(request, callArgument)),
+        });
+    }
+};

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/createFunctionCallTypesMutation.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/createFunctionCallTypesMutation.ts
@@ -1,0 +1,96 @@
+import { combineMutations, ITextSwapMutation } from "automutate";
+import * as ts from "typescript";
+import { findAliasOfTypes } from "../../../../../mutations/aliasing/findAliasOfTypes";
+import { joinIntoType } from "../../../../../mutations/aliasing/joinIntoType";
+
+import { collectOptionals, isNotUndefined } from "../../../../../shared/arrays";
+import { TypeElementWithStaticName } from "../../../../../shared/nodeTypes";
+import { FileMutationsRequest } from "../../../../fileMutator";
+import { ReactComponentPropsNode } from "../getComponentPropsNode";
+import { FunctionCallType } from "./collectAllFunctionCallTypes";
+
+type CombinedFunctionType = {
+    parameters: ts.Type[][];
+    returnValue?: ts.Type[];
+};
+
+export const createFunctionCallTypesMutation = (
+    request: FileMutationsRequest,
+    propsNode: ReactComponentPropsNode,
+    allFunctionCallTypes: Map<TypeElementWithStaticName, FunctionCallType[]>,
+) => {
+    const mutations = Array.from(allFunctionCallTypes).map(([member, functionCallTypes]) => {
+        return createFunctionCallTypeMutation(request, member, functionCallTypes);
+    });
+
+    return mutations === undefined ? undefined : combineMutations(...mutations);
+};
+
+const createFunctionCallTypeMutation = (
+    request: FileMutationsRequest,
+    member: TypeElementWithStaticName,
+    functionCallTypes: FunctionCallType[],
+): ITextSwapMutation => {
+    const combinedType = functionCallTypes.reduce<CombinedFunctionType>(
+        (accum, functionCallType) => {
+            return {
+                parameters: combineParameters(request, accum.parameters, functionCallType.parameters),
+                returnValue: collectOptionals(accum.returnValue, [functionCallType.returnValue]).filter(isNotUndefined),
+            };
+        },
+        {
+            parameters: [],
+            returnValue: [],
+        },
+    );
+
+    return {
+        insertion: `${member.name.text}: ${printFunctionType(request, combinedType)}`,
+        range: {
+            begin: member.getStart(request.sourceFile),
+            end: member.end,
+        },
+        type: "text-swap",
+    };
+};
+
+const combineParameters = (request: FileMutationsRequest, previous: ts.Type[][], next: (ts.Type | undefined)[] | undefined) => {
+    if (next === undefined) {
+        return previous;
+    }
+
+    const combined: ts.Type[][] = [];
+    let i: number;
+
+    for (i = 0; i < previous.length; i += 1) {
+        combined.push([...previous[i]]);
+
+        if (i < next.length && next[i] !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            combined[i].push(next[i]!);
+        }
+    }
+
+    for (i; i < next.length; i += 1) {
+        if (next[i] !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            combined.push([next[i]!]);
+        }
+    }
+
+    return combined;
+};
+
+const printFunctionType = (request: FileMutationsRequest, combinedType: CombinedFunctionType) => {
+    return [
+        "(",
+        combinedType.parameters
+            ?.map((parameter, index) => `arg${index}: ${joinIntoType(new Set(), new Set(parameter), request)}`)
+            .join(", "),
+        ") => ",
+        combinedType.returnValue?.length
+            ? joinIntoType(new Set(), new Set(combinedType.returnValue), request)
+            : findAliasOfTypes(request, ["void"]),
+        ";",
+    ].join("");
+};

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/index.ts
@@ -1,15 +1,15 @@
-import { createTypeExpansionMutation } from "../../../../../mutations/expansions/expansionMutations";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
 import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
 import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
-import { getComponentAssignedTypesFromUsage } from "./getComponentAssignedTypesFromUsage";
 import { getComponentPropsNode } from "../getComponentPropsNode";
+import { collectAllFunctionCallTypes } from "./collectAllFunctionCallTypes";
+import { createFunctionCallTypesMutation } from "./createFunctionCallTypesMutation";
 
 /**
- * Expands the existing props type for a component from its external JSX-style declarations.
+ * Expands a component's props declared as Function to be more specific types.
  */
-export const fixReactPropsFromLaterAssignments: FileMutator = (request) => {
+export const fixReactPropFunctionsFromCalls: FileMutator = (request) => {
     return collectMutationsFromNodes(request, isReactComponentNode, visitReactComponentNode);
 };
 
@@ -20,11 +20,11 @@ const visitReactComponentNode = (node: ReactComponentNode, request: FileMutation
         return undefined;
     }
 
-    // Find all types of props later passed to the node
-    const componentAssignedTypes = getComponentAssignedTypesFromUsage(request, node);
-    if (componentAssignedTypes === undefined || componentAssignedTypes.length === 0) {
+    // Find all Function prop calls used internally within the node
+    const allFunctionCallTypes = collectAllFunctionCallTypes(request, propsNode);
+    if (allFunctionCallTypes === undefined) {
         return undefined;
     }
 
-    return createTypeExpansionMutation(request, propsNode, componentAssignedTypes);
+    return createFunctionCallTypesMutation(request, propsNode, allFunctionCallTypes);
 };

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
@@ -7,7 +7,7 @@ import { FileMutationsRequest } from "../../../../fileMutator";
 import { ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 /**
- * Finds all assigned types for properties in each JSX usage of a React component.
+ * Finds all assigned types for props in each JSX usage of a React component.
  */
 export const getComponentAssignedTypesFromUsage = (
     request: FileMutationsRequest,

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getComponentPropsNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getComponentPropsNode.ts
@@ -1,9 +1,9 @@
 import * as ts from "typescript";
 
-import { getClassExtendsType } from "../../../../../shared/nodes";
-import { getTypeAtLocationIfNotError } from "../../../../../shared/types";
-import { FileMutationsRequest } from "../../../../fileMutator";
-import { ReactClassComponentNode, ReactComponentNode, ReactFunctionalComponentNode } from "../reactFiltering/isReactComponentNode";
+import { getClassExtendsType } from "../../../../shared/nodes";
+import { getTypeAtLocationIfNotError } from "../../../../shared/types";
+import { FileMutationsRequest } from "../../../fileMutator";
+import { ReactClassComponentNode, ReactComponentNode, ReactFunctionalComponentNode } from "./reactFiltering/isReactComponentNode";
 
 export type ReactComponentPropsNode = ts.InterfaceDeclaration | ts.TypeLiteralNode;
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/index.ts
@@ -3,11 +3,11 @@ import { FileMutationsRequest } from "../../../fileMutator";
 
 import { fixReactPropsFromLaterAssignments } from "./fixReactPropsFromLaterAssignments";
 import { fixReactPropsFromPropTypes } from "./fixReactPropsFromPropTypes";
+import { fixReactPropFunctionsFromCalls } from "./fixReactPropFunctionsFromCalls";
 
 export const fixIncompleteReactTypes = (request: FileMutationsRequest) =>
     findFirstMutations(request, [
         ["fixReactPropsFromPropTypes", fixReactPropsFromPropTypes],
         ["fixReactPropsFromLaterAssignments", fixReactPropsFromLaterAssignments],
-        // Todo: also add a fixReactPropsWithoutPropTypes
-        // This would be equivalen to expansionMutations, but like a typeCreationMutation
+        ["fixReactPropFunctionsFromCalls", fixReactPropFunctionsFromCalls],
     ]);

--- a/src/mutators/fileMutator.ts
+++ b/src/mutators/fileMutator.ts
@@ -2,7 +2,6 @@ import { IMutation } from "automutate";
 import * as ts from "typescript";
 
 import { TypeStatOptions } from "../options/types";
-import { ProcessOutput } from "../output";
 import { LanguageServices } from "../services/language";
 import { FileInfoCache } from "../shared/FileInfoCache";
 import { NameGenerator } from "../shared/NameGenerator";

--- a/src/shared/comparisons.ts
+++ b/src/shared/comparisons.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { FileMutationsRequest } from "../mutators/fileMutator";
 import { ExposedTypeChecker } from "../mutations/createExposedTypeScript";
-import { isIntrisinicNameTypeNode, isOptionalTypeArgumentsTypeNode } from "./typeNodes";
+import { isIntrisinicNameType, isOptionalTypeArgumentsTypeNode } from "./typeNodes";
 import { getTypeAtLocationIfNotError } from "./types";
 
 export const declaredInitializedTypeNodeIsRedundant = (request: FileMutationsRequest, declaration: ts.TypeNode, initializer: ts.Node) => {
@@ -61,7 +61,7 @@ const declaredTypeIsEquivalent = (typeChecker: ExposedTypeChecker, declaredType:
 
     // We have to hackily check for boolean types with intrinsic names...
     // `boolean[]` is really the type `[false, true]`
-    if (isIntrisinicNameTypeNode(declaredType) && isIntrisinicNameTypeNode(initializedType)) {
+    if (isIntrisinicNameType(declaredType) && isIntrisinicNameType(initializedType)) {
         return intrinsicNamesAreEquivalent(declaredType.intrinsicName, initializedType.intrinsicName);
     }
 

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -70,6 +70,16 @@ export const isNodeWithDefinedTypeParameters = (node: ts.Node): node is NodeWith
     return "typeParameters" in node;
 };
 
+export type TypeElementWithStaticName = ts.TypeElement & {
+    name: {
+        text: string;
+    };
+};
+
+export const isTypeElementWithStaticName = (node: ts.TypeElement): node is TypeElementWithStaticName => {
+    return node.name !== undefined && "text" in node.name;
+};
+
 export const getValueDeclarationOfType = (request: FileMutationsRequest, node: ts.Node): ts.Node | undefined => {
     // Try getting the symbol at the location, which sometimes only works in the latter form
     const nodeType = getTypeAtLocationIfNotError(request, node);

--- a/src/shared/typeNodes.ts
+++ b/src/shared/typeNodes.ts
@@ -4,7 +4,7 @@ export type TypeWithTypeArguments = ts.Type & {
     typeArguments: ts.Type[];
 };
 
-export const isTypeArgumentsTypeNode = (type: ts.Type): type is TypeWithTypeArguments => {
+export const isTypeArgumentsType = (type: ts.Type): type is TypeWithTypeArguments => {
     return "typeArguments" in type;
 };
 
@@ -20,6 +20,16 @@ export type TypeWithIntrinsicName = ts.Type & {
     intrinsicName: string;
 };
 
-export const isIntrisinicNameTypeNode = (type: ts.Type): type is TypeWithIntrinsicName => {
+export const isIntrisinicNameType = (type: ts.Type): type is TypeWithIntrinsicName => {
     return "intrinsicName" in type;
+};
+
+export type TypeWithValue = ts.Type & {
+    value: string;
+};
+
+export const isTypeWithValue = (type: ts.Type): type is TypeWithValue => {
+    {
+    }
+    return "value" in type;
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 import { FileMutationsRequest } from "../mutators/fileMutator";
-import { isIntrisinicNameTypeNode } from "./typeNodes";
+import { isIntrisinicNameType } from "./typeNodes";
 
 /**
  * @returns Whether the type has `localTypeParameters`, such as the built-in Map and Array definitions.
@@ -29,5 +29,5 @@ export const getTypeAtLocationIfNotError = (request: FileMutationsRequest, node:
 
     const type = request.services.program.getTypeChecker().getTypeAtLocation(node);
 
-    return isIntrisinicNameTypeNode(type) && type.intrinsicName === "error" ? undefined : type;
+    return isIntrisinicNameType(type) && type.intrinsicName === "error" ? undefined : type;
 };

--- a/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/expected.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+(function () {
+    // interface ClassComponentProps {
+        
+    // }
+
+    // class ClassComponent extends React.Component<ClassComponentProps> {
+    //     render() {
+    //         if (this.props.other) {
+    //             return '';
+    //         }
+
+    //         return this.props.text;    
+    //     }
+    // }
+        
+    // type FunctionComponentProps =  {
+    //     other?: boolean;
+    // }
+
+    // class FunctionComponent extends React.Component<FunctionComponentProps> {
+    //     render() {
+    //         return this.props.texts.join('');
+    //     }
+    // }
+
+    type WithFunctionsProps = {
+        providesNothing: () => void;
+        providesString: (arg0: string) => void;
+        providesNumberThenString: (arg0: number, arg1: string) => void;
+        providesBooleanGivesNumber: (arg0: boolean) => number;
+        returnsString: () => string;
+    }
+
+    class WithFunctions extends React.Component<WithFunctionsProps> {
+        onClick = () => {
+            this.props.providesNothing();
+            this.props.providesString("");
+            this.props.providesNumberThenString(0, "");
+            this.callReceiveNumber(this.props.providesBooleanGivesNumber(true));
+            this.callReceiveString(this.props.returnsString());
+        }
+
+        callReceiveNumber = (value: number) => value;
+        callReceiveString = (text: string) => text;
+    }
+})();

--- a/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/expected.tsx
@@ -1,29 +1,29 @@
 import * as React from 'react';
 
 (function () {
-    // interface ClassComponentProps {
+    interface ClassComponentProps {
         
-    // }
+    }
 
-    // class ClassComponent extends React.Component<ClassComponentProps> {
-    //     render() {
-    //         if (this.props.other) {
-    //             return '';
-    //         }
+    class ClassComponent extends React.Component<ClassComponentProps> {
+        render() {
+            if (this.props.other) {
+                return '';
+            }
 
-    //         return this.props.text;    
-    //     }
-    // }
+            return this.props.text;    
+        }
+    }
         
-    // type FunctionComponentProps =  {
-    //     other?: boolean;
-    // }
+    type FunctionComponentProps =  {
+        other: () => void;
+    }
 
-    // class FunctionComponent extends React.Component<FunctionComponentProps> {
-    //     render() {
-    //         return this.props.texts.join('');
-    //     }
-    // }
+    class FunctionComponent extends React.Component<FunctionComponentProps> {
+        render() {
+            return this.props.texts.join('');
+        }
+    }
 
     type WithFunctionsProps = {
         providesNothing: () => void;

--- a/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/original.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/original.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+(function () {
+    interface ClassComponentProps {
+        
+    }
+
+    class ClassComponent extends React.Component<ClassComponentProps> {
+        render() {
+            if (this.props.other) {
+                return '';
+            }
+
+            return this.props.text;    
+        }
+    }
+        
+    type FunctionComponentProps =  {
+        other?: boolean;
+    }
+
+    class FunctionComponent extends React.Component<FunctionComponentProps> {
+        render() {
+            return this.props.texts.join('');
+        }
+    }
+
+    type WithFunctionsProps = {
+        providesNothing: Function;
+        providesString: Function;
+        providesNumberThenString: Function;
+        providesBooleanGivesNumber: Function;
+        returnsString: Function;
+    }
+
+    class WithFunctions extends React.Component<WithFunctionsProps> {
+        onClick = () => {
+            this.props.providesNothing();
+            this.props.providesString("");
+            this.props.providesNumberThenString(0, "");
+            this.callReceiveNumber(this.props.providesBooleanGivesNumber(true));
+            this.callReceiveString(this.props.returnsString());
+        }
+
+        callReceiveNumber = (value: number) => value;
+        callReceiveString = (text: string) => text;
+    }
+})();

--- a/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/tsconfig.json
+++ b/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "jsx": "react"
+    },
+    "files": ["actual.tsx"]
+}

--- a/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/typestat.json
+++ b/test/cases/fixes/incompleteTypes/reactTypes/fixReactPropFunctionsFromCalls/typestat.json
@@ -1,0 +1,5 @@
+{
+    "fixes": {
+        "incompleteTypes": true
+    }
+}


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #766
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds a React fixer for _specifically_ the `Function` types that tend to be output by other React fixers.

TypeScript unfortunately does not provide a good API for this (#761) so I made logic around `parameters` and `returnValue` options specifically for this fixer. Eventually it might make sense to generalize that, if more cases like this come up -- or even use `ts-simple-type`.

Adds a lazilly retrieved `wellKnownTypes: WellKnownTypes` to the language services. I ended up not using it here but it's nifty. 🤷 