### PR TITLE
Added 'all done' message on successful CLI completion

### DIFF
--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -52,7 +52,7 @@ describe("runCli", () => {
         const resultStatus = await runCli(argv, { initializationRunner, output, mainRunner });
 
         // Assert
-        expect(output.stderr).toHaveBeenLastCalledWith(jasmine.stringMatching(message));
+        expect(output.stderr).toHaveBeenLastCalledWith(expect.stringMatching(message));
         expect(resultStatus).toEqual(ResultStatus.Failed);
     });
 
@@ -70,8 +70,24 @@ describe("runCli", () => {
         const resultStatus = await runCli(argv, { initializationRunner, output, mainRunner });
 
         // Assert
-        expect(output.stdout).toHaveBeenLastCalledWith(jasmine.stringMatching("typestat \\[options\\]"));
-        expect(output.stderr).toHaveBeenLastCalledWith(jasmine.stringMatching(message));
+        expect(output.stdout).toHaveBeenLastCalledWith(expect.stringMatching("typestat \\[options\\]"));
+        expect(output.stderr).toHaveBeenLastCalledWith(expect.stringMatching(message));
         expect(resultStatus).toEqual(ResultStatus.ConfigurationError);
+    });
+
+    it("logs a happy message when it finishes succesfully", async () => {
+        // Arrange
+        const { argv, initializationRunner, output, mainRunner } = createTestArgs("--config", "typestat.json");
+
+        mainRunner.mockResolvedValue({
+            status: ResultStatus.Succeeded,
+        });
+
+        // Act
+        const resultStatus = await runCli(argv, { initializationRunner, output, mainRunner });
+
+        // Assert
+        expect(output.stdout).toHaveBeenLastCalledWith(expect.stringMatching("All done!"));
+        expect(resultStatus).toEqual(ResultStatus.Succeeded);
     });
 });

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -74,6 +74,10 @@ export const runCli = async (rawArgv: ReadonlyArray<string>, runtime?: CliRuntim
         case ResultStatus.Failed:
             runtime.output.stderr(chalk.yellow(result.error));
             break;
+
+        case ResultStatus.Succeeded:
+            runtime.output.stdout(chalk.blue("All done! ✨"));
+            break;
     }
 
     return result.status;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to TypeStat! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #774
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

```
All done! ✨
```

Also uses `expect.stringMatching` instead of `jasmine.stringMatching`. I'd learned about `expect` after first writing these tests... 😄 