### PR TITLE
Fixed using wrong TS/TSX enum value

### DIFF
--- a/src/initialization/initializeJavaScript/renames.ts
+++ b/src/initialization/initializeJavaScript/renames.ts
@@ -9,7 +9,7 @@ export enum InitializationRenames {
 export const initializeRenames = async () => {
     const { renames } = await prompt<{ renames: InitializationRenames }>([
         {
-            choices: [InitializationRenames.Auto, InitializationRenames.TS, InitializationRenames.TS],
+            choices: [InitializationRenames.Auto, InitializationRenames.TS, InitializationRenames.TSX],
             initial: 0,
             message: "How would you like .js files to be renamed?",
             name: "renames",


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #924
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Oops.