### PR TITLE
Error if node_modules is included by accident

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export const typeStat = async (argv: TypeStatArgv, output: ProcessOutput): Promi
             status: ResultStatus.ConfigurationError,
         };
     }
-
+    
     for (let i = 0; i < allOptions.length; i += 1) {
         // First run any any file renames needed as part of project setup
         const options = await processFileRenames(allOptions[i]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,6 @@ export const typeStat = async (argv: TypeStatArgv, output: ProcessOutput): Promi
             status: ResultStatus.ConfigurationError,
         };
     }
-    
     for (let i = 0; i < allOptions.length; i += 1) {
         // First run any any file renames needed as part of project setup
         const options = await processFileRenames(allOptions[i]);


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #796
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

If at least one path includes `node_modules`, but that wasn't explicitly in the include list, error.
