### PR TITLE
Fixed printing for incomplete implicit generics

### DIFF
--- a/src/mutations/generics.ts
+++ b/src/mutations/generics.ts
@@ -9,13 +9,16 @@ import { constructArrayShorthand } from "./arrays";
  * Creates a type like "string[]" or "Map<boolean | number>" from a container and type arguments.
  */
 export const joinIntoGenericType = (request: FileMutationsRequest, containerType: ts.Type, allTypeArgumentTypes: ts.Type[][]) => {
-    const containerTypeName = request.services.printers.type(containerType);
+    const containerTypeName = request.services.printers
+        .type(containerType, undefined, ts.TypeFormatFlags.WriteArrayAsGenericType)
+        // Names with parameters like Array<T> and Map<K, V> should ignore those parameters
+        .split("<")[0];
 
     // By now we're assuming the generic types can all be named
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const genericTypeNames = allTypeArgumentTypes.map((genericTypes) => request.services.printers.type(genericTypes)!);
 
-    if (containerTypeName === "Array" && isTypeBuiltIn(containerType)) {
+    if (containerTypeName.split("<")[0] === "Array" && isTypeBuiltIn(containerType)) {
         return constructArrayShorthand(genericTypeNames);
     }
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/createExplicitGenericType.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/createExplicitGenericType.ts
@@ -1,6 +1,8 @@
+import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
 import { joinIntoGenericType } from "../../../../../mutations/generics";
+import { isTypeArgumentsType } from "../../../../../shared/typeNodes";
 import { FileMutationsRequest } from "../../../../fileMutator";
 
 import { GenericClassDetails } from "./getGenericClassDetails";
@@ -32,6 +34,11 @@ export const createExplicitGenericType = (
         return undefined;
     }
 
+    // If the node's inferred generic type already contains the later types, don't change anything
+    if (allTypeArgumentTypesMatch(request, allTypeArgumentTypes, node)) {
+        return undefined;
+    }
+
     // Convert the container and its type assignments into a labeled type
     const joinedGenericType = joinIntoGenericType(request, genericClassDetails.containerType, allTypeArgumentTypes);
     if (joinedGenericType === undefined) {
@@ -45,4 +52,39 @@ export const createExplicitGenericType = (
         },
         type: "text-insert",
     };
+};
+
+const allTypeArgumentTypesMatch = (request: FileMutationsRequest, allTypeArgumentTypes: ts.Type[][], node: ts.Node) => {
+    const typeChecker = request.services.program.getTypeChecker();
+
+    // If the original type doesn't have type arguments, bail out immediately
+    const originalType = typeChecker.getTypeAtLocation(node);
+    if (!isTypeArgumentsType(originalType)) {
+        return false;
+    }
+
+    // If the implicit type has defaulted to any, ignore it (assume a non-match)
+    if (originalType.typeArguments.some((typeArgument) => tsutils.isTypeFlagSet(typeArgument, ts.TypeFlags.Any))) {
+        return false;
+    }
+
+    // If the implicit types are all unknown, assume a non-match for being unknown
+    if (originalType.typeArguments.every((typeArgument) => tsutils.isTypeFlagSet(typeArgument, ts.TypeFlags.Unknown))) {
+        return false;
+    }
+
+    // Otherwise, check that all type arguments sub-types match the original type at the same index
+    for (const typeArgumentTypes of allTypeArgumentTypes) {
+        if (typeArgumentTypes.length !== originalType.typeArguments.length) {
+            return false;
+        }
+
+        for (let i = 0; i < typeArgumentTypes.length; i += 1) {
+            if (!typeChecker.isTypeAssignableTo(typeArgumentTypes[i], originalType.typeArguments[i])) {
+                return false;
+            }
+        }
+    }
+
+    return true;
 };

--- a/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitVariableGenerics/expected.ts
+++ b/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitVariableGenerics/expected.ts
@@ -1,25 +1,33 @@
 (function () {
     class Name { }
 
+    const stringsInferred = [''];
+    stringsInferred.push('');
+
+    const stringsExplicit: string[] = [];
+    stringsExplicit.push('');
+
+    const stringsMissing: string[] = [];
+    stringsMissing.push('');
+
     let name = new Name();
 
-    let names: T[]<Name> = [];
+    let names: Name[] = [];
     names.push(new Name());
 
-    let uniqueNames: Set<T><Name> = new Set();
+    let uniqueNames: Set<Name> = new Set();
     uniqueNames.add(name);
 
-    let namesById: Map<K, V><string, Name> = new Map();
+    let namesById: Map<string, Name> = new Map();
     namesById.set('abc123', new Name())
 
-    let idsByName: Map<K, V><Name, number> = new Map();
+    let idsByName: Map<Name, number> = new Map();
     idsByName.set(new Name(), 123);
 
-    // TODO: fix me :)
-    let uniqueMaybeNames: Set<T><any> = new Set();
-    uniqueMaybeNames.add(idsByName.get(123));
+    let uniqueMaybeNames: Set<number> = new Set();
+    uniqueMaybeNames.add(Math.random() > 0.5 ? 123 : undefined)
 
-    let uniqueNamesOrBooleans: Set<T><Name | boolean> = new Set();
+    let uniqueNamesOrBooleans: Set<Name | boolean> = new Set();
     uniqueNamesOrBooleans.add(name);
     uniqueNamesOrBooleans.add(false);
 })();

--- a/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitVariableGenerics/original.ts
+++ b/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitVariableGenerics/original.ts
@@ -1,6 +1,15 @@
 (function () {
     class Name { }
 
+    const stringsInferred = [''];
+    stringsInferred.push('');
+
+    const stringsExplicit: string[] = [];
+    stringsExplicit.push('');
+
+    const stringsMissing = [];
+    stringsMissing.push('');
+
     let name = new Name();
 
     let names = [];
@@ -15,9 +24,8 @@
     let idsByName = new Map();
     idsByName.set(new Name(), 123);
 
-    // TODO: fix me :)
     let uniqueMaybeNames = new Set();
-    uniqueMaybeNames.add(idsByName.get(123));
+    uniqueMaybeNames.add(Math.random() > 0.5 ? 123 : undefined)
 
     let uniqueNamesOrBooleans = new Set();
     uniqueNamesOrBooleans.add(name);


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #959
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Two changes:

* Restricts printing to only happen when the existing inferred generic type doesn't contain later-added ones
* Fixes printing to properly treat generics such as maps as having a type name like `"Map"`, not `"Map<K, V>"`