### PR TITLE
Added inference for missing implicit generic function members

### DIFF
--- a/src/mutations/expansions/eliminations.ts
+++ b/src/mutations/expansions/eliminations.ts
@@ -3,14 +3,22 @@ import * as ts from "typescript";
 import { FileMutationsRequest } from "../../mutators/fileMutator";
 import { isKnownGlobalBaseType, isNeverAndOrUnknownType } from "../../shared/nodeTypes";
 
+const onlyTypes = (candidateTypes: ReadonlyArray<ts.Type | string>): candidateTypes is ReadonlyArray<ts.Type> =>
+    !candidateTypes.some((candidateType) => typeof candidateType === "string");
+
 /**
  * @returns Whether any of the extra types don't yet exist on an original type.
+ * @remarks If any of the candidate types are strings, this unfortunately has to assume true.
  */
 export const originalTypeHasIncompleteType = (
     request: FileMutationsRequest,
     originalType: ts.Type,
-    candidateTypes: ReadonlyArray<ts.Type>,
+    candidateTypes: ReadonlyArray<ts.Type | string>,
 ) => {
+    if (!onlyTypes(candidateTypes)) {
+        return true;
+    }
+
     // If the original type is something like Function and at least one candidate type isn't,
     // consider the Function to be reporting not enough info (like a base type)
     if (isKnownGlobalBaseType(originalType) && !candidateTypes.every(isKnownGlobalBaseType)) {

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/collectTypeParameterReferences.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/collectTypeParameterReferences.ts
@@ -35,6 +35,8 @@ export const collectTypeParameterReferences = (
 };
 
 const findParentExpandedReferences = (request: FileMutationsRequest, node: ts.Node) => {
+    node = getEquivalentContainingTypeNode(node);
+
     // Property and variable declarations can be directly searched for as references
     if (ts.isParameterPropertyDeclaration(node, node.parent) || ts.isPropertyDeclaration(node) || ts.isVariableDeclaration(node)) {
         return request.fileInfoCache.getNodeReferencesAsNodes(node);
@@ -58,3 +60,11 @@ const findParentExpandedReferences = (request: FileMutationsRequest, node: ts.No
 
     return undefined;
 };
+
+const getEquivalentContainingTypeNode = (node: ts.Node) => {
+    while (ts.isIntersectionTypeNode(node.parent)) {
+        node = node.parent.parent;
+    }
+
+    return node;
+}

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 
 import { AssignedTypesByName, AssignedTypeValue, joinAssignedTypesByName } from "../../../../mutations/assignments";
+import { getCallExpressionType } from "../../../../shared/calls";
 import { getStaticNameOfProperty } from "../../../../shared/names";
 import { isNodeAssigningBinaryExpression, isNodeWithinNode } from "../../../../shared/nodes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
@@ -155,6 +156,14 @@ const collectMissingAssignedTypesOnChildClassNode = (
             parentPropertyAccess.parent.right,
             true /* asStandaloneProperty */,
         );
+    }
+
+    // If we're calling the member reference as a function, grab the perceived function type
+    if (ts.isCallExpression(parentPropertyAccess.parent.parent) && ts.isPropertyAccessExpression(parentPropertyAccess.parent)) {
+        return {
+            name: parentPropertyAccess.parent.name.text,
+            type: getCallExpressionType(request, parentPropertyAccess.parent.parent)
+        };
     }
 
     // Otherwise we ignore any other types

--- a/src/services/language.ts
+++ b/src/services/language.ts
@@ -41,7 +41,7 @@ export interface LanguageServices {
 export interface Printers {
     readonly node: (node: ts.Node) => string;
     readonly type: (
-        types: ts.Type | ReadonlyArray<ts.Type>,
+        types: ts.Type | string | ReadonlyArray<ts.Type | string>,
         enclosingDeclaration?: ts.Node,
         typeFormatFlags?: ts.TypeFormatFlags,
     ) => string;
@@ -85,13 +85,15 @@ export const createLanguageServices = (options: TypeStatOptions): LanguageServic
             const typeChecker = program.getTypeChecker();
             return uniquify(
                 ...arrayify(types).map((type) =>
-                    typeChecker.typeToString(
-                        // Our mutations generally always go for base primitives, not literals
-                        // This might need to be revisited for potential future high fidelity types...
-                        typeChecker.getBaseTypeOfLiteralType(type),
-                        enclosingDeclaration,
-                        typeFormatFlags,
-                    ),
+                    typeof type === "string"
+                        ? type
+                        : typeChecker.typeToString(
+                              // Our mutations generally always go for base primitives, not literals
+                              // This might need to be revisited for potential future high fidelity types...
+                              typeChecker.getBaseTypeOfLiteralType(type),
+                              enclosingDeclaration,
+                              typeFormatFlags,
+                          ),
                 ),
             ).join(" | ");
         },

--- a/src/shared/calls.ts
+++ b/src/shared/calls.ts
@@ -36,3 +36,14 @@ export const getDeclaredTypesOfArgument = (
 
     return declaredTypes;
 };
+
+export const getCallExpressionType = (request: FileMutationsRequest, parentCall: ts.CallExpression) => {
+    const typeChecker = request.services.program.getTypeChecker();
+    const argumentTypes = parentCall.arguments.map((argument) => typeChecker.getTypeAtLocation(argument));
+
+    return [
+        "((",
+        argumentTypes.map((parameter, index) => `arg${index}: ${request.services.printers.type(parameter)}`).join(", "),
+        ") => unknown)",
+    ].join("");
+};

--- a/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitClassGenerics/expected.ts
+++ b/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitClassGenerics/expected.ts
@@ -69,6 +69,17 @@ import { ComponentLike } from './react-like';
         };
     }
 
+
+    class MemberImmediateFunction extends MemberImmediateBase<{}, { key: (arg0: boolean) => void; }> {
+        member = {
+            key: (arg0: boolean) => {}
+        };
+
+        addToState = () => {
+            this.setMember({ key: (arg0: boolean) => {} });
+        };
+    }
+
     class MemberCurriedBase<First = {}> {
         member: First;
 

--- a/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitClassGenerics/original.ts
+++ b/test/cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitClassGenerics/original.ts
@@ -64,6 +64,16 @@ import { ComponentLike } from './react-like';
         };
     }
 
+    class MemberImmediateFunction extends MemberImmediateBase {
+        member = {
+            key: (arg0: boolean) => {}
+        };
+
+        addToState = () => {
+            this.setMember({ key: (arg0: boolean) => {} });
+        };
+    }
+
     class MemberCurriedBase<First = {}> {
         member: First;
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #964
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

This test coverage isn't particularly great but at this point I'm just generally dissatisfied with how the type inference for implicit generics is structured...