### PR TITLE
Stopped adding non-null assertions on already-asserted property accesses

### DIFF
--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
@@ -16,6 +16,11 @@ export const fixStrictNonNullAssertionPropertyAccesses: FileMutator = (request: 
 };
 
 const getStrictPropertyAccessFix = (request: FileMutationsRequest, node: ts.PropertyAccessExpression): IMutation | undefined => {
+    // Early on skip checking for "!" needs if there already is one
+    if (ts.isAssertionExpression(node.parent) || ts.isNonNullExpression(node.parent)) {
+        return undefined;
+    }
+
     // Grab the type of the property being accessed by name
     const expressionType = getTypeAtLocationIfNotError(request, node.expression);
 

--- a/test/cases/fixes/strictNonNullAssertions/propertyAccesses/expected.ts
+++ b/test/cases/fixes/strictNonNullAssertions/propertyAccesses/expected.ts
@@ -10,6 +10,8 @@
         
         givenTwiceDifferent: number;
 
+        givenAlreadyAsserted: number;
+
         def() {
             this.givenNumber = 1;
             this.givenNumberOrUndefined = (1 as number | undefined)!;
@@ -20,6 +22,8 @@
 
             this.givenTwiceDifferent = 1;
             this.givenTwiceDifferent = undefined!;
+
+            this.givenAlreadyAsserted = undefined!;
         }
     }
 

--- a/test/cases/fixes/strictNonNullAssertions/propertyAccesses/original.ts
+++ b/test/cases/fixes/strictNonNullAssertions/propertyAccesses/original.ts
@@ -10,6 +10,8 @@
         
         givenTwiceDifferent: number;
 
+        givenAlreadyAsserted: number;
+
         def() {
             this.givenNumber = 1;
             this.givenNumberOrUndefined = 1 as number | undefined;
@@ -20,6 +22,8 @@
 
             this.givenTwiceDifferent = 1;
             this.givenTwiceDifferent = undefined;
+
+            this.givenAlreadyAsserted = undefined!;
         }
     }
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1005
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

If a property access expression is already a child of a non-null assertion, we don't need to check whether it needs to receive a non-null assertion.