### PR TITLE
Fix expressions nested in object literals

### DIFF
--- a/src/mutations/typeMutating/createNonNullAssertion.ts
+++ b/src/mutations/typeMutating/createNonNullAssertion.ts
@@ -16,7 +16,12 @@ const wrappedKinds = new Set([
     ts.SyntaxKind.VoidExpression,
 ]);
 
-export const createNonNullAssertion = (request: FileMutationsRequest, node: ts.Node): ITextInsertMutation | ITextSwapMutation => {
+export const createNonNullAssertion = (request: FileMutationsRequest, node: ts.Node): ITextInsertMutation | ITextSwapMutation => {  
+    // For property assignments (`key: value`), create a non-null assertion only for `value`.
+    if(ts.isPropertyAssignment(node)) {
+        node = node.initializer;
+    }
+
     // If the node must be wrapped in parenthesis, replace all of it
     if (wrappedKinds.has(node.kind)) {
         return {

--- a/test/cases/fixes/strictNonNullAssertions/objectLiterals/expected.ts
+++ b/test/cases/fixes/strictNonNullAssertions/objectLiterals/expected.ts
@@ -27,3 +27,20 @@
     const takesContainedValue = (arg: ContainedValues) => { };
     takesContainedValue({ first: first!, ok, second: second! });
 })();
+
+// Nested values
+(function () {
+    const A = {
+        id: undefined
+    } as { id: boolean | undefined } | undefined
+    
+    type B = { C: boolean }
+
+    const B1: B = {
+        C: (A && A.id)!
+    }
+    
+    const B2: B = {
+        C: A?.id!
+    }
+})();

--- a/test/cases/fixes/strictNonNullAssertions/objectLiterals/original.ts
+++ b/test/cases/fixes/strictNonNullAssertions/objectLiterals/original.ts
@@ -27,3 +27,20 @@
     const takesContainedValue = (arg: ContainedValues) => { };
     takesContainedValue({ first: first, ok, second });
 })();
+
+// Nested values
+(function () {
+    const A = {
+        id: undefined
+    } as { id: boolean | undefined } | undefined
+    
+    type B = { C: boolean }
+
+    const B1: B = {
+        C: A && A.id
+    }
+    
+    const B2: B = {
+        C: A?.id
+    }
+})();


### PR DESCRIPTION
## PR Checklist

-   [ x ] Addresses an existing issue: fixes #1012
-   [ x ] That issue was marked as [`status: accepting prs`]

## Overview

Added test case for type of issue described in #1012. Summary of fix:

We are passing the `PropertyAssignment` node to `createNonNullAssertion`, which then goes ahead and adds the `!` character. `PropertyAssignment` nodes look like `C: A && A.id`, which is transformed to `C: A && A.id` + `!`.

As is already dealt with in `createNonNullAssertion`, there are certain types of expressions that require extra wrapping in parenthesis. To fix this issue, we simply use the RHS (`initializer`) of `PropertyAssignment` (which can be some type of expressions requiring wrapping). This allows us to properly deal with more complex initializer expressions.
