### PR TITLE
Don't add non null assertions to optional chaining

### DIFF
--- a/src/mutations/codeFixes/noImplicitAny.ts
+++ b/src/mutations/codeFixes/noImplicitAny.ts
@@ -33,7 +33,7 @@ export const canNodeBeFixedForNoImplicitAny = (node: NoImplicitAnyNode): node is
 
 export const getNoImplicitAnyMutations = (node: NoImplictAnyNodeToBeFixed, request: FileMutationsRequest): Mutation | undefined => {
     // If the node is a parameter, make sure it doesn't already have an inferable type
-    // (TypeScript will still suggest a codefix to make a reundant inferred type)
+    // (TypeScript will still suggest a codefix to make a redundant inferred type)
     if (ts.isParameter(node)) {
         const nodeType = getTypeAtLocationIfNotError(request, node);
         if (nodeType === undefined || !tsutils.isTypeFlagSet(nodeType, ts.TypeFlags.Any)) {

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionBinaryExpressions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionBinaryExpressions/index.ts
@@ -1,4 +1,5 @@
 import { Mutation } from "automutate";
+import { isTypeFlagSet } from "tsutils";
 import * as ts from "typescript";
 
 import { isTypeFlagSetRecursively } from "../../../../mutations/collecting/flags";
@@ -20,7 +21,7 @@ const visitBinaryExpression = (node: ts.BinaryExpression, request: FileMutations
     }
 
     const declaredType = getTypeAtLocationIfNotError(request, node.left);
-    if (declaredType === undefined) {
+    if (declaredType === undefined || isTypeFlagSet(declaredType, ts.TypeFlags.Any)) {
         return undefined;
     }
 

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
@@ -16,8 +16,8 @@ export const fixStrictNonNullAssertionPropertyAccesses: FileMutator = (request: 
 };
 
 const getStrictPropertyAccessFix = (request: FileMutationsRequest, node: ts.PropertyAccessExpression): Mutation | undefined => {
-    // Early on skip checking for "!" needs if there already is one
-    if (ts.isAssertionExpression(node.parent) || ts.isNonNullExpression(node.parent)) {
+    // Early on skip checking for "!" needs if there already is one or it's a ?.
+    if (ts.isAssertionExpression(node.parent) || ts.isNonNullExpression(node.parent) || node.questionDotToken) {
         return undefined;
     }
 
@@ -30,5 +30,5 @@ const getStrictPropertyAccessFix = (request: FileMutationsRequest, node: ts.Prop
     }
 
     // Add a mutation to insert a "!" before the access
-    return createNonNullAssertion(request, node);
+    return createNonNullAssertion(request, node.expression);
 };

--- a/test/cases/fixes/strictNonNullAssertions/binaryExpressions/expected.ts
+++ b/test/cases/fixes/strictNonNullAssertions/binaryExpressions/expected.ts
@@ -1,4 +1,13 @@
 (function () {
+    let implicitAnyDirectUndefined;
+    implicitAnyDirectUndefined = undefined;
+
+    let implicitAnyDirectNull;
+    implicitAnyDirectNull = null;
+
+    let implicitAnyTernary;
+    implicitAnyTernary = Math.random() > 0.5 ? undefined : '';
+
     function improperStringOrUndefined(text: string | undefined) {
         let recipient = '';
         recipient = text!;

--- a/test/cases/fixes/strictNonNullAssertions/binaryExpressions/original.ts
+++ b/test/cases/fixes/strictNonNullAssertions/binaryExpressions/original.ts
@@ -1,4 +1,13 @@
 (function () {
+    let implicitAnyDirectUndefined;
+    implicitAnyDirectUndefined = undefined;
+
+    let implicitAnyDirectNull;
+    implicitAnyDirectNull = null;
+
+    let implicitAnyTernary;
+    implicitAnyTernary = Math.random() > 0.5 ? undefined : '';
+
     function improperStringOrUndefined(text: string | undefined) {
         let recipient = '';
         recipient = text;

--- a/test/cases/fixes/strictNonNullAssertions/propertyAccesses/expected.ts
+++ b/test/cases/fixes/strictNonNullAssertions/propertyAccesses/expected.ts
@@ -1,4 +1,18 @@
 (function () {
+    declare const value: string | undefined;
+
+    value!.length;
+    value?.length;
+    
+    declare const valueAny: any;
+
+    valueAny.length;
+    valueAny?.length;
+
+    declare const valueAnyOrUndefined: any | undefined;
+
+    valueAnyOrUndefined.length;
+    valueAnyOrUndefined?.length;
     
     // Internal declarations
     class Abc {
@@ -68,4 +82,202 @@
     container.givenString = "";
     container.givenStringHasNull = "";
     container.givenStringHasNull = "";
+
+    // Nested type shapes
+
+    function withNullableString(value: string | undefined) {
+        value!.length;
+    }
+
+    interface NotNullable {
+        a: {
+            b: {
+                c: number;
+            }
+        }
+    }
+
+    function withNotNullable(value: NotNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalNotNullable(value?: NotNullable) {
+        value!.a.b.c.toPrecision(0);
+        value!.a?.b.c.toPrecision(0);
+        value!.a?.b?.c.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b.c?.toPrecision(0);
+        value!.a.b.c?.toPrecision(0);
+        value!.a.b?.c.toPrecision(0);
+    }
+
+    function withPartialNotNullable(value: Partial<NotNullable>) {
+        value.a!.b.c.toPrecision(0);
+        value.a?.b!.c!.toPrecision(0);
+        value.a?.b?.c!.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b!.c?.toPrecision(0);
+        value.a!.b.c?.toPrecision(0);
+        value.a!.b?.c.toPrecision(0);
+    }
+
+    function withOptionalPartialNotNullable(value?: Partial<NotNullable>) {
+        value!.a!.b.c.toPrecision(0);
+        value!.a?.b!.c!.toPrecision(0);
+        value!.a?.b?.c!.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b!.c?.toPrecision(0);
+        value!.a!.b.c?.toPrecision(0);
+        value!.a!.b?.c.toPrecision(0);
+    }
+
+    interface OuterNullable {
+        a?: {
+            b: {
+                c: number;
+            }
+        }
+    }
+
+    function withOuterNullable(value: OuterNullable) {
+        value.a!.b.c.toPrecision(0);
+        value.a?.b!.c!.toPrecision(0);
+        value.a?.b?.c!.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b!.c?.toPrecision(0);
+        value.a!.b.c?.toPrecision(0);
+        value.a!.b?.c.toPrecision(0);
+    }
+
+    function withOptionalOuterNullable(value?: OuterNullable) {
+        value!.a!.b.c.toPrecision(0);
+        value!.a?.b!.c!.toPrecision(0);
+        value!.a?.b?.c!.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b!.c?.toPrecision(0);
+        value!.a!.b.c?.toPrecision(0);
+        value!.a!.b?.c.toPrecision(0);
+    }
+
+    function withPartialOuterNullable(value: Partial<OuterNullable>) {
+        value.a!.b.c.toPrecision(0);
+        value.a?.b!.c!.toPrecision(0);
+        value.a?.b?.c!.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b!.c?.toPrecision(0);
+        value.a!.b.c?.toPrecision(0);
+        value.a!.b?.c.toPrecision(0);
+    }
+
+    function withOptionalPartialOuterNullable(value?: Partial<OuterNullable>) {
+        value!.a!.b.c.toPrecision(0);
+        value!.a?.b!.c!.toPrecision(0);
+        value!.a?.b?.c!.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b!.c?.toPrecision(0);
+        value!.a!.b.c?.toPrecision(0);
+        value!.a!.b?.c.toPrecision(0);
+    }
+
+    interface MiddleNullable {
+        a: {
+            b?: {
+                c: number;
+            }
+        }
+    }
+
+    function withMiddleNullable(value: MiddleNullable) {
+        value.a.b!.c.toPrecision(0);
+        value.a?.b!.c.toPrecision(0);
+        value.a?.b?.c!.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b!.c?.toPrecision(0);
+        value.a.b!.c?.toPrecision(0);
+        value.a.b?.c!.toPrecision(0);
+    }
+
+    function withOptionalMiddleNullable(value?: MiddleNullable) {
+        value!.a.b!.c.toPrecision(0);
+        value!.a?.b!.c.toPrecision(0);
+        value!.a?.b?.c!.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b!.c?.toPrecision(0);
+        value!.a.b!.c?.toPrecision(0);
+        value!.a.b?.c!.toPrecision(0);
+    }
+
+    function withPartialMiddleNullable(value: Partial<MiddleNullable>) {
+        value.a!.b!.c.toPrecision(0);
+        value.a?.b!.c!.toPrecision(0);
+        value.a?.b?.c!.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b!.c?.toPrecision(0);
+        value.a!.b!.c?.toPrecision(0);
+        value.a!.b?.c!.toPrecision(0);
+    }
+
+    function withOptionalPartialMiddleNullable(value?: Partial<MiddleNullable>) {
+        value!.a!.b!.c.toPrecision(0);
+        value!.a?.b!.c!.toPrecision(0);
+        value!.a?.b?.c!.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b!.c?.toPrecision(0);
+        value!.a!.b!.c?.toPrecision(0);
+        value!.a!.b?.c!.toPrecision(0);
+    }
+
+    interface InnerNullable {
+        a: {
+            b: {
+                c?: number;
+            }
+        }
+    }
+
+    function withInnerNullable(value: InnerNullable) {
+        value.a.b.c!.toPrecision(0);
+        value.a?.b.c!.toPrecision(0);
+        value.a?.b?.c!.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c!.toPrecision(0);
+    }
+
+    function withOptionalInnerNullable(value?: InnerNullable) {
+        value!.a.b.c!.toPrecision(0);
+        value!.a?.b.c!.toPrecision(0);
+        value!.a?.b?.c!.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b.c?.toPrecision(0);
+        value!.a.b.c?.toPrecision(0);
+        value!.a.b?.c!.toPrecision(0);
+    }
+
+    function withPartialInnerNullable(value: Partial<InnerNullable>) {
+        value.a!.b.c!.toPrecision(0);
+        value.a?.b!.c!.toPrecision(0);
+        value.a?.b?.c!.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b!.c?.toPrecision(0);
+        value.a!.b.c?.toPrecision(0);
+        value.a!.b?.c!.toPrecision(0);
+    }
+
+    function withOptionalPartialInnerNullable(value?: Partial<InnerNullable>) {
+        value!.a!.b.c!.toPrecision(0);
+        value!.a?.b!.c!.toPrecision(0);
+        value!.a?.b?.c!.toPrecision(0);
+        value!.a?.b?.c?.toPrecision(0);
+        value!.a?.b!.c?.toPrecision(0);
+        value!.a!.b.c?.toPrecision(0);
+        value!.a!.b?.c!.toPrecision(0);
+    }
 })();

--- a/test/cases/fixes/strictNonNullAssertions/propertyAccesses/original.ts
+++ b/test/cases/fixes/strictNonNullAssertions/propertyAccesses/original.ts
@@ -1,4 +1,18 @@
 (function () {
+    declare const value: string | undefined;
+
+    value.length;
+    value?.length;
+    
+    declare const valueAny: any;
+
+    valueAny.length;
+    valueAny?.length;
+
+    declare const valueAnyOrUndefined: any | undefined;
+
+    valueAnyOrUndefined.length;
+    valueAnyOrUndefined?.length;
     
     // Internal declarations
     class Abc {
@@ -68,4 +82,202 @@
     container.givenString = "";
     container.givenStringHasNull = "";
     container.givenStringHasNull = "";
+
+    // Nested type shapes
+
+    function withNullableString(value: string | undefined) {
+        value.length;
+    }
+
+    interface NotNullable {
+        a: {
+            b: {
+                c: number;
+            }
+        }
+    }
+
+    function withNotNullable(value: NotNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalNotNullable(value?: NotNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withPartialNotNullable(value: Partial<NotNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalPartialNotNullable(value?: Partial<NotNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    interface OuterNullable {
+        a?: {
+            b: {
+                c: number;
+            }
+        }
+    }
+
+    function withOuterNullable(value: OuterNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalOuterNullable(value?: OuterNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withPartialOuterNullable(value: Partial<OuterNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalPartialOuterNullable(value?: Partial<OuterNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    interface MiddleNullable {
+        a: {
+            b?: {
+                c: number;
+            }
+        }
+    }
+
+    function withMiddleNullable(value: MiddleNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalMiddleNullable(value?: MiddleNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withPartialMiddleNullable(value: Partial<MiddleNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalPartialMiddleNullable(value?: Partial<MiddleNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    interface InnerNullable {
+        a: {
+            b: {
+                c?: number;
+            }
+        }
+    }
+
+    function withInnerNullable(value: InnerNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalInnerNullable(value?: InnerNullable) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withPartialInnerNullable(value: Partial<InnerNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
+
+    function withOptionalPartialInnerNullable(value?: Partial<InnerNullable>) {
+        value.a.b.c.toPrecision(0);
+        value.a?.b.c.toPrecision(0);
+        value.a?.b?.c.toPrecision(0);
+        value.a?.b?.c?.toPrecision(0);
+        value.a?.b.c?.toPrecision(0);
+        value.a.b.c?.toPrecision(0);
+        value.a.b?.c.toPrecision(0);
+    }
 })();


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1019
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds a couple of checks around binary expressions:

* Don't add `!` if the declared type is `any`
* Create a non-null assertion on the node expression, not the node itself

These changes were sitting on my local repo clone for two months. I'd completely forgotten about them until opening the repo with @beyang! 😂