### PR TITLE
Smarter regexp checking and unit tests for files.renameExtensions

### DIFF
--- a/src/options/getNewFileName.test.ts
+++ b/src/options/getNewFileName.test.ts
@@ -1,0 +1,46 @@
+import { getNewFileName } from "./getNewFileName";
+import { RenameExtensions } from "./types";
+
+describe(getNewFileName, () => {
+    it("returns a .ts path when renameExtensions is ts", async () => {
+        const actual = await getNewFileName("ts", "path/name.js", jest.fn());
+
+        expect(actual).toBe("path/name.ts");
+    });
+
+    it("returns a .tsx path when renameExtensions is tsx", async () => {
+        const actual = await getNewFileName("tsx", "path/name.js", jest.fn());
+
+        expect(actual).toBe("path/name.tsx");
+    });
+
+    it.each([
+        { extension: ".ts", name: "no closing tags", text: "<>" },
+        { extension: ".tsx", name: "an intrinsic closing tag", text: "< /div >" },
+        { extension: ".tsx", name: "a custom closing tag", text: "< /Custom.Tag >" },
+        { extension: ".tsx", name: "a fragment closing tag", text: "</>" },
+        { extension: ".tsx", name: "a self closing tag", text: "/>" },
+    ])("returns a $extension path when renameExtensions is true and the file contains $name", async ({ extension, text }) => {
+        const actual = await getNewFileName(
+            true,
+            "path/name.js",
+            jest.fn().mockResolvedValue(`
+            ${text}        
+            `),
+        );
+
+        expect(actual).toBe(`path/name${extension}`);
+    });
+
+    it("returns a .tsx path when renameExtensions is true and the file contains a fragment closing tag", async () => {
+        const actual = await getNewFileName(
+            true,
+            "path/name.js",
+            jest.fn().mockResolvedValue(`
+            </>
+        `),
+        );
+
+        expect(actual).toBe("path/name.tsx");
+    });
+});

--- a/src/options/getNewFileName.test.ts
+++ b/src/options/getNewFileName.test.ts
@@ -31,16 +31,4 @@ describe(getNewFileName, () => {
 
         expect(actual).toBe(`path/name${extension}`);
     });
-
-    it("returns a .tsx path when renameExtensions is true and the file contains a fragment closing tag", async () => {
-        const actual = await getNewFileName(
-            true,
-            "path/name.js",
-            jest.fn().mockResolvedValue(`
-            </>
-        `),
-        );
-
-        expect(actual).toBe("path/name.tsx");
-    });
 });

--- a/src/options/getNewFileName.ts
+++ b/src/options/getNewFileName.ts
@@ -1,0 +1,23 @@
+import { RenameExtensions } from "./types";
+
+export const getNewFileName = async (
+    renameExtensions: RenameExtensions,
+    oldFileName: string,
+    readFile: (filePath: string) => Promise<string>,
+): Promise<string> => {
+    const oldExtension = oldFileName.substring(oldFileName.lastIndexOf("."));
+    const beforeExtension = oldFileName.substring(0, oldFileName.length - oldExtension.length);
+
+    if (typeof renameExtensions === "string") {
+        return `${beforeExtension}.${renameExtensions}`;
+    }
+
+    const fileContents = (await readFile(oldFileName)).toString();
+    const fileContentsJoined = fileContents.replace(/ /g, "").replace(/"/g, "'");
+
+    if (/(<\s*\/\s*[A-z\.]*\s*>)|(\/\s*>)/.test(fileContentsJoined)) {
+        return `${beforeExtension}.tsx`;
+    }
+
+    return `${beforeExtension}.ts`;
+};

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -162,8 +162,13 @@ export interface Files {
     /**
      * Whether to convert .js(x) files to .ts(x).
      */
-    renameExtensions: boolean | "ts" | "tsx";
+    renameExtensions: RenameExtensions;
 }
+
+/**
+ * Setting value for whether to convert .js(x) files to .ts(x).
+ */
+export type RenameExtensions = boolean | "ts" | "tsx";
 
 /**
  * Cross-file settings for forms of fixes.


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #93
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds a smarter heuristic for whether to switch to `.tsx`: checks for closing JSX tags, rather than importing `react`.
