### PR TITLE
Add fixer for React components with missing prop types

### DIFF
--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -62,7 +62,7 @@ export const createTypeAdditionMutation = (
  * Creates a mutation to add types to a node without a type, if any are new.
  *
  * @param request   Metadata and settings to collect mutations in a file.
- * @param begin   Starting position to add types at.
+ * @param node   Node to add the type annotation.
  * @param declaredType   Declared type from the node.
  * @param allAssignedTypes   Types now assigned to the node.
  * @returns Mutation to add any new assigned types, if any are missing from the declared type.

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/createInterfaceFromPropTypes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/createInterfaceFromPropTypes.ts
@@ -1,8 +1,7 @@
-import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
-import { getFriendlyFileName } from "../../../../../../shared/fileNames";
 import { FileMutationsRequest } from "../../../../../fileMutator";
+import { getApparentNameOfComponent } from "../../getApparentNameOfComponent";
 import { ReactComponentNode } from "../../reactFiltering/isReactComponentNode";
 
 import { createPropTypesProperty } from "./propTypesProperties";
@@ -33,18 +32,4 @@ export const createInterfaceFromPropTypes = (
     );
 
     return { interfaceName, interfaceNode };
-};
-
-export const getApparentNameOfComponent = (request: FileMutationsRequest, node: ReactComponentNode): string | undefined => {
-    // If the node itself has a name, great!
-    if (node.name !== undefined) {
-        return node.name.text;
-    }
-
-    // If the node is the default export of its file, use the file's name
-    if (tsutils.hasModifier(node.modifiers, ts.SyntaxKind.DefaultKeyword)) {
-        return getFriendlyFileName(request.sourceFile.fileName);
-    }
-
-    return "AnonymousClass";
 };

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsMissing.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsMissing.ts
@@ -1,0 +1,189 @@
+import { combineMutations } from "automutate";
+import * as ts from "typescript";
+import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
+import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { isReactComponentNode, ReactComponentNode } from "./reactFiltering/isReactComponentNode";
+import { getComponentPropsNode } from "./getComponentPropsNode";
+import { getApparentNameOfComponent } from "./getApparentNameOfComponent";
+import { printNewLine } from "../../../../shared/printing/newlines";
+
+/**
+ * Creates a new props type for a React component from scratch.
+ */
+export const fixReactPropsMissing: FileMutator = (request) => {
+    return collectMutationsFromNodes(request, isReactComponentNode, visitReactComponentNode);
+};
+
+const visitReactComponentNode = (node: ReactComponentNode, request: FileMutationsRequest) => {
+    // Make sure a node doesn't yet exist to declare the node's props type
+    const propsNode = getComponentPropsNode(request, node);
+    if (propsNode !== undefined) {
+        return undefined;
+    }
+
+    // Find all types of props later passed to the node
+    const attributeTypesAndRequirements = collectComponentAttributeTypes(request, node);
+    if (!attributeTypesAndRequirements?.attributeTypes.size) {
+        return undefined;
+    }
+
+    // Generate a name for a new props interface to use on the node
+    const interfaceName = `${getApparentNameOfComponent(request, node)}Props`;
+
+    return combineMutations(
+        // That interface will be injected with blank lines around it just before the component
+        createPropsTypeCreationMutation(request, node, interfaceName, attributeTypesAndRequirements),
+        // We'll also annotate the component with a type declaration to use the new prop type
+        createPropsTypeUsageMutation(node, interfaceName),
+    );
+};
+
+const collectComponentAttributeTypes = (request: FileMutationsRequest, node: ReactComponentNode) => {
+    // Find all references to the node, if there are more than just the node itself
+    const references = request.fileInfoCache.getNodeReferencesAsNodes(
+        node.parent.kind === ts.SyntaxKind.VariableDeclaration ? node.parent : node,
+    );
+    if (references === undefined || references.length === 0) {
+        return undefined;
+    }
+
+    const allAttributeNames = new Set<string>();
+    const allAttributeNameUses: Set<string>[] = [];
+    const attributeTypes = new Map<string, ts.Type[]>();
+
+    // For each reference, try to collect attribute type from its usage...
+    for (const reference of references) {
+        // ...assuming the reference is a JSX element used with attributes
+        const attributesElement = getAttributesElement(reference);
+        if (attributesElement === undefined) {
+            continue;
+        }
+
+        // Keep track of attribute names that are used, so later we can figure out which are optional
+        const usedAttributeNames: string[] = [];
+
+        for (const attribute of attributesElement.attributes.properties) {
+            // Only look at JSX attributes, like prop={value} and prop
+            if (!ts.isJsxAttribute(attribute)) {
+                continue;
+            }
+
+            // Attempt to retrieve the type of the prop's value
+            const typeChecker = request.services.program.getTypeChecker();
+            const valueType = getAttributeValueType(typeChecker, attribute);
+            if (valueType === undefined) {
+                continue;
+            }
+
+            // Widen literals such as `false` to their primitives such as `boolean`
+            const type = typeChecker.getBaseTypeOfLiteralType(valueType);
+
+            // Add the type underneath the attribute name
+            const name = attribute.name.text;
+            const types = attributeTypes.get(name);
+            if (types === undefined) {
+                attributeTypes.set(name, [type]);
+            } else {
+                types.push(type);
+            }
+
+            // Remember the attribute name in all attributes, and in this usage (element)
+            allAttributeNames.add(name);
+            usedAttributeNames.push(name);
+        }
+
+        allAttributeNameUses.push(new Set(usedAttributeNames));
+    }
+
+    // Mark only the attributes that appear in every usage as required
+    const requiredAttributeNames = new Set(
+        Array.from(allAttributeNames).filter((attributeName) =>
+            allAttributeNameUses.every((attributeNameUses) => attributeNameUses.has(attributeName)),
+        ),
+    );
+
+    return { attributeTypes, requiredAttributeNames };
+};
+
+const getAttributesElement = (reference: ts.Node) => {
+    if (!ts.isIdentifier(reference)) {
+        return undefined;
+    }
+
+    const { parent } = reference;
+
+    if (ts.isJsxElement(parent)) {
+        return parent.openingElement;
+    }
+
+    if (ts.isJsxSelfClosingElement(parent)) {
+        return parent;
+    }
+
+    return undefined;
+};
+
+const getAttributeValueType = (typeChecker: ts.TypeChecker, attribute: ts.JsxAttribute) => {
+    if (attribute.initializer) {
+        if (ts.isStringLiteral(attribute.initializer)) {
+            return typeChecker.getTypeAtLocation(attribute);
+        }
+
+        return ts.isJsxExpression(attribute.initializer) && attribute.initializer.expression
+            ? typeChecker.getTypeAtLocation(attribute.initializer.expression)
+            : undefined;
+    }
+
+    return typeChecker.getTypeAtLocation(attribute.name);
+};
+
+interface AttributeTypesAndRequirements {
+    attributeTypes: Map<string, ts.Type[]>;
+    requiredAttributeNames: Set<string>;
+}
+
+const createPropsTypeCreationMutation = (
+    request: FileMutationsRequest,
+    node: ReactComponentNode,
+    interfaceName: string,
+    { attributeTypes, requiredAttributeNames }: AttributeTypesAndRequirements,
+) => {
+    const endline = printNewLine(request.options.compilerOptions);
+
+    return {
+        insertion: [
+            endline,
+            `interface ${interfaceName} {`,
+            ...Array.from(attributeTypes).map(
+                ([name, type]) => `${name}${requiredAttributeNames.has(name) ? "" : "?"}: ${request.services.printers.type(type)};`,
+            ),
+            `}`,
+        ].join(endline),
+        range: {
+            begin: ts.isClassDeclaration(node)
+                ? node.pos
+                : ts.isVariableDeclaration(node.parent)
+                ? node.parent.parent.pos
+                : node.parent.pos,
+        },
+        type: "text-insert",
+    };
+};
+
+const createPropsTypeUsageMutation = (node: ReactComponentNode, interfaceName: string) => {
+    return ts.isFunctionLike(node)
+        ? {
+              insertion: `: ${interfaceName}`,
+              range: {
+                  begin: node.parameters[0].end,
+              },
+              type: "text-insert",
+          }
+        : {
+              insertion: `<${interfaceName}>`,
+              range: {
+                  begin: node.heritageClauses[0].end,
+              },
+              type: "text-insert",
+          };
+};

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getApparentNameOfComponent.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getApparentNameOfComponent.ts
@@ -1,0 +1,28 @@
+import * as tsutils from "tsutils";
+import * as ts from "typescript";
+
+import { getFriendlyFileName } from "../../../../shared/fileNames";
+import { FileMutationsRequest } from "../../../fileMutator";
+import { ReactComponentNode } from "./reactFiltering/isReactComponentNode";
+
+/**
+ * @returns The name of a class or function component, if determinable.
+ */
+export const getApparentNameOfComponent = (request: FileMutationsRequest, node: ReactComponentNode) => {
+    // If the node itself has a name, great!
+    if (node.name !== undefined) {
+        return node.name.text;
+    }
+
+    // If the node in a single named variable declaration, use that
+    if (ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)) {
+        return node.parent.name.text;
+    }
+
+    // If the node is the default export of its file, use the file's name
+    if (tsutils.hasModifier(node.modifiers, ts.SyntaxKind.DefaultKeyword)) {
+        return getFriendlyFileName(request.sourceFile.fileName);
+    }
+
+    return "AnonymousComponent";
+};

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/index.ts
@@ -5,6 +5,7 @@ import { fixReactPropsFromLaterAssignments } from "./fixReactPropsFromLaterAssig
 import { fixReactPropsFromUses } from "./fixReactPropsFromUses";
 import { fixReactPropsFromPropTypes } from "./fixReactPropsFromPropTypes";
 import { fixReactPropFunctionsFromCalls } from "./fixReactPropFunctionsFromCalls";
+import { fixReactPropsMissing } from "./fixReactPropsMissing";
 
 export const fixIncompleteReactTypes = (request: FileMutationsRequest) =>
     findFirstMutations(request, [
@@ -15,6 +16,10 @@ export const fixIncompleteReactTypes = (request: FileMutationsRequest) =>
 
         ["fixReactPropFunctionsFromCalls", fixReactPropFunctionsFromCalls],
 
-        // Fill in any missing explicitly declared prop types as a last resort
+        // Use propTypes with lower priority than uses, assignments, and calls
+        // In practical code they are often wrong
         ["fixReactPropsFromPropTypes", fixReactPropsFromPropTypes],
+
+        // Lastly, if the component is missing a props type altogether, create one from scratch
+        ["fixReactPropsMissing", fixReactPropsMissing],
     ]);

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
@@ -4,7 +4,9 @@ import { getClassExtendsType } from "../../../../../shared/nodes";
 
 export type ReactComponentNode = ReactClassComponentNode | ReactFunctionalComponentNode;
 
-export type ReactClassComponentNode = ts.ClassDeclaration | ts.ClassExpression;
+export type ReactClassComponentNode = (ts.ClassDeclaration | ts.ClassExpression) & {
+    heritageClauses: ts.NodeArray<ts.HeritageClause>;
+};
 
 export type ReactFunctionalComponentNode = ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression;
 
@@ -17,8 +19,8 @@ export const isReactComponentNode = (node: ts.Node): node is ReactComponentNode 
         return node.parameters.length <= 1;
     }
 
-    // Otherwise, we only look at class declarations
-    if (!ts.isClassDeclaration(node)) {
+    // Otherwise, we only look at class declarations and class expressions
+    if (!ts.isClassLike(node)) {
         return false;
     }
 

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/expected.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+
+(function () {
+    interface SomeValue {
+        value: string;
+    }
+
+    const someValue: SomeValue = { value: "" };
+
+interface ManyPropsProps {
+always: boolean;
+isBoolean?: boolean;
+isNumber?: number;
+isString?: string;
+isNumbers?: number;
+isStrings?: string;
+isNumberOrString?: number | string;
+isNumberOrStringArray?: number[] | string[] | (string | number)[];
+isObject?: SomeValue;
+}
+
+    const ManyProps = (props: ManyPropsProps) => <div />;
+
+    const renderManyProps = () => [
+        <ManyProps always isBoolean />,
+        <ManyProps always isNumber={0} />,
+        <ManyProps always isString="" />,
+        <ManyProps always isNumbers={1} />,
+        <ManyProps always isNumbers={2} />,
+        <ManyProps always isStrings="a" />,
+        <ManyProps always isStrings="b" />,
+        <ManyProps always isNumberOrString={3} />,
+        <ManyProps always isNumberOrString="c" />,
+        <ManyProps always isNumberOrStringArray={[3]} />,
+        <ManyProps always isNumberOrStringArray={["c"]} />,
+        <ManyProps always isNumberOrStringArray={[3, "c"]} />,
+        <ManyProps always isObject={someValue} />,
+        <ManyProps always isObject={someValue} />,
+    ]
+
+interface SinglePropArrowFunctionProps {
+prop: number[];
+}
+
+    const SinglePropArrowFunction = ({ prop }: SinglePropArrowFunctionProps) => {
+        console.log(prop);
+        return <div />;
+    };
+
+    const renderSinglePropArrowFunction = () => <SinglePropArrowFunction prop={[1, 2, 3]} />;
+
+interface SinglePropFunctionExpressionAnonymousProps {
+prop: number[];
+}
+
+    const SinglePropFunctionExpressionAnonymous = function ({ prop }: SinglePropFunctionExpressionAnonymousProps) {
+        console.log(prop);
+        return <div />;
+    };
+
+    const renderSinglePropFunctionExpressionAnonymous = () => <SinglePropFunctionExpressionAnonymous prop={[1, 2, 3]} />;
+
+interface FunctionExpressionNamedProps {
+prop: number[];
+}
+
+    const SinglePropFunctionExpressionNamed = function FunctionExpressionNamed({ prop }: FunctionExpressionNamedProps) {
+        console.log(prop);
+        return <div />;
+    };
+
+    const renderSinglePropFunctionExpressionNamed = () => <SinglePropFunctionExpressionNamed prop={[1, 2, 3]} />;
+
+interface SinglePropClassExpressionProps {
+prop: number[];
+}
+
+    const SinglePropClassExpression = class extends React.Component<SinglePropClassExpressionProps> {
+        render() {
+            return <div />;
+        }
+    };
+
+    const renderSinglePropClassExpression = () => <SinglePropClassExpression prop={[1, 2, 3]} />;
+
+interface SinglePropClassDeclarationProps {
+prop: number[];
+}
+
+    class SinglePropClassDeclaration extends React.Component<SinglePropClassDeclarationProps> {
+        render() {
+            return <div />;
+        }
+    };
+
+    const renderSinglePropClassDeclaration = () => <SinglePropClassDeclaration prop={[1, 2, 3]} />;
+
+})();

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/original.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/original.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+
+(function () {
+    interface SomeValue {
+        value: string;
+    }
+
+    const someValue: SomeValue = { value: "" };
+
+    const ManyProps = (props) => <div />;
+
+    const renderManyProps = () => [
+        <ManyProps always isBoolean />,
+        <ManyProps always isNumber={0} />,
+        <ManyProps always isString="" />,
+        <ManyProps always isNumbers={1} />,
+        <ManyProps always isNumbers={2} />,
+        <ManyProps always isStrings="a" />,
+        <ManyProps always isStrings="b" />,
+        <ManyProps always isNumberOrString={3} />,
+        <ManyProps always isNumberOrString="c" />,
+        <ManyProps always isNumberOrStringArray={[3]} />,
+        <ManyProps always isNumberOrStringArray={["c"]} />,
+        <ManyProps always isNumberOrStringArray={[3, "c"]} />,
+        <ManyProps always isObject={someValue} />,
+        <ManyProps always isObject={someValue} />,
+    ]
+
+    const SinglePropArrowFunction = ({ prop }) => {
+        console.log(prop);
+        return <div />;
+    };
+
+    const renderSinglePropArrowFunction = () => <SinglePropArrowFunction prop={[1, 2, 3]} />;
+
+    const SinglePropFunctionExpressionAnonymous = function ({ prop }) {
+        console.log(prop);
+        return <div />;
+    };
+
+    const renderSinglePropFunctionExpressionAnonymous = () => <SinglePropFunctionExpressionAnonymous prop={[1, 2, 3]} />;
+
+    const SinglePropFunctionExpressionNamed = function FunctionExpressionNamed({ prop }) {
+        console.log(prop);
+        return <div />;
+    };
+
+    const renderSinglePropFunctionExpressionNamed = () => <SinglePropFunctionExpressionNamed prop={[1, 2, 3]} />;
+
+    const SinglePropClassExpression = class extends React.Component {
+        render() {
+            return <div />;
+        }
+    };
+
+    const renderSinglePropClassExpression = () => <SinglePropClassExpression prop={[1, 2, 3]} />;
+
+    class SinglePropClassDeclaration extends React.Component {
+        render() {
+            return <div />;
+        }
+    };
+
+    const renderSinglePropClassDeclaration = () => <SinglePropClassDeclaration prop={[1, 2, 3]} />;
+
+})();

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/tsconfig.json
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "jsx": "react"
+    },
+    "files": ["actual.tsx"]
+}

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/typestat.json
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/typestat.json
@@ -1,0 +1,5 @@
+{
+    "fixes": {
+        "incompleteTypes": true
+    }
+}


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1036
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

For a React component that doesn't have a `prop-types` `.propTypes` definition or an existing TypeScript props interface/type, creates a new one from scratch. It does so by finding each usage of the component and collecting named JSX element attributes & their types.