### PR TITLE
fix: support TSConfig include globs

### DIFF
--- a/src/options/parseRawCompilerOptions.ts
+++ b/src/options/parseRawCompilerOptions.ts
@@ -1,4 +1,5 @@
 import minimatch from "minimatch";
+import glob from "glob";
 import * as fs from "mz/fs";
 import * as path from "path";
 import * as ts from "typescript";
@@ -30,9 +31,7 @@ export const parseRawCompilerOptions = async (cwd: string, projectPath: string):
                 useCaseSensitiveFileNames: true,
                 readDirectory: (rootDir, extensions, excludes, includes) =>
                     includes
-                        .flatMap((include) =>
-                            fs.readdirSync(path.join(rootDir, include)).map((fileName) => path.join(rootDir, include, fileName)),
-                        )
+                        .flatMap((include) => glob.sync(path.join(rootDir, include)))
                         .filter(
                             (filePath) =>
                                 !excludes?.some((exclude) => minimatch(filePath, exclude)) &&


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1060
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Uses `glob.sync` instead of fancy file path concatenation. Simpler!
