### PR TITLE
fix: account for bottom and top types in incompleteTypes unions

### DIFF
--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -1,4 +1,5 @@
 import { TextInsertMutation, TextSwapMutation } from "automutate";
+import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
 import { FileMutationsRequest } from "../mutators/fileMutator";
@@ -36,8 +37,8 @@ export const createTypeAdditionMutation = (
         return undefined;
     }
 
-    // If the original type was just something like Function or Object, replace it entirely
-    if (isKnownGlobalBaseType(declaredType)) {
+    // If the original type was a bottom type or just something like Function or Object, replace it entirely
+    if (tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Never | ts.TypeFlags.Unknown) || isKnownGlobalBaseType(declaredType)) {
         return {
             insertion: ` ${newTypeAlias}`,
             range: {

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
@@ -19,7 +19,7 @@ const visitPropertyDeclaration = (node: ts.PropertyDeclaration, request: FileMut
     // Collect types later assigned to the property, and types initially declared by or inferred on the property
     const assignedTypes = collectPropertyAssignedTypes(node, request);
     const declaredType = getTypeAtLocationIfNotError(request, node);
-    if (declaredType === undefined) {
+    if (declaredType === undefined || tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)) {
         return undefined;
     }
 

--- a/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/expected.ts
@@ -29,7 +29,7 @@
         method() {
             this.member = {
                 key: true,
-            }
+            };
         }
     }
 
@@ -37,10 +37,10 @@
         member: string | { key: boolean; };
 
         method() {
-            this.member = '';
+            this.member = "";
             this.member = {
                 key: true,
-            }
+            };
         }
     }
 
@@ -48,13 +48,34 @@
         member: string | { middle: { deepKey: boolean; }; middleKey: number; };
 
         method() {
-            this.member = '';
+            this.member = "";
             this.member = {
                 middle: {
                     deepKey: true,
                 },
                 middleKey: 0,
-            }
+            };
         }
     }
+
+    class WithAny {
+        property: any;
+    }
+
+    const withAny = new WithAny();
+    withAny.property = "";
+
+    class WithUnknown {
+        property: string;
+    }
+
+    const withUnknown = new WithUnknown();
+    withUnknown.property = "";
+
+    class WithNever {
+        property: string;
+    }
+
+    const withNever = new WithNever();
+    withNever.property = "";
 })();

--- a/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/propertyDeclarationTypes/original.ts
@@ -29,7 +29,7 @@
         method() {
             this.member = {
                 key: true,
-            }
+            };
         }
     }
 
@@ -37,10 +37,10 @@
         member: string;
 
         method() {
-            this.member = '';
+            this.member = "";
             this.member = {
                 key: true,
-            }
+            };
         }
     }
 
@@ -48,13 +48,34 @@
         member: string;
 
         method() {
-            this.member = '';
+            this.member = "";
             this.member = {
                 middle: {
                     deepKey: true,
                 },
                 middleKey: 0,
-            }
+            };
         }
     }
+
+    class WithAny {
+        property: any;
+    }
+
+    const withAny = new WithAny();
+    withAny.property = "";
+
+    class WithUnknown {
+        property: unknown;
+    }
+
+    const withUnknown = new WithUnknown();
+    withUnknown.property = "";
+
+    class WithNever {
+        property: never;
+    }
+
+    const withNever = new WithNever();
+    withNever.property = "";
 })();


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1063
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

* `any`-typed properties are never incomplete, so the fixer should bail out early
* `never`- and `unknown`-typed properties are replaced altogether
