### PR TITLE
feat: create TSConfig in CLI

### DIFF
--- a/src/initialization/initializeJavaScript/createJavaScriptConfig.test.ts
+++ b/src/initialization/initializeJavaScript/createJavaScriptConfig.test.ts
@@ -13,7 +13,9 @@ describe(createJavaScriptConfig, () => {
             name: "Basic",
             settings: {
                 imports: InitializationImports.No,
-                project: "tsconfig.json",
+                project: {
+                    filePath: "tsconfig.json",
+                },
                 renames: InitializationRenames.TS,
             },
         },
@@ -34,7 +36,9 @@ describe(createJavaScriptConfig, () => {
             name: "TS Renames (multiple sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
-                project: "tsconfig.json",
+                project: {
+                    filePath: "tsconfig.json",
+                },
                 renames: InitializationRenames.TS,
                 sourceFiles: "src/**/*.{js,jsx}",
             },
@@ -56,7 +60,9 @@ describe(createJavaScriptConfig, () => {
             name: "TSX Renames (multiple sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
-                project: "tsconfig.json",
+                project: {
+                    filePath: "tsconfig.json",
+                },
                 renames: InitializationRenames.TSX,
                 sourceFiles: "src/**/*.{js,jsx}",
             },
@@ -69,7 +75,9 @@ describe(createJavaScriptConfig, () => {
             name: "Auto Renames (no sourceFiles)",
             settings: {
                 imports: InitializationImports.Yes,
-                project: "tsconfig.json",
+                project: {
+                    filePath: "tsconfig.json",
+                },
                 renames: InitializationRenames.Auto,
             },
         },
@@ -90,7 +98,9 @@ describe(createJavaScriptConfig, () => {
             name: "Auto Renames (single sourceFiles extension)",
             settings: {
                 imports: InitializationImports.Yes,
-                project: "tsconfig.json",
+                project: {
+                    filePath: "tsconfig.json",
+                },
                 renames: InitializationRenames.Auto,
                 sourceFiles: "src/**/*.js",
             },
@@ -112,7 +122,9 @@ describe(createJavaScriptConfig, () => {
             name: "Auto Renames (multiple sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
-                project: "tsconfig.json",
+                project: {
+                    filePath: "tsconfig.json",
+                },
                 renames: InitializationRenames.Auto,
                 sourceFiles: "src/**/*.{js,jsx}",
             },
@@ -134,7 +146,9 @@ describe(createJavaScriptConfig, () => {
             name: "Auto Renames (parenthesized sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
-                project: "tsconfig.json",
+                project: {
+                    filePath: "tsconfig.json",
+                },
                 renames: InitializationRenames.Auto,
                 sourceFiles: "src/**/*.js(x)",
             },

--- a/src/initialization/initializeJavaScript/createJavaScriptConfig.ts
+++ b/src/initialization/initializeJavaScript/createJavaScriptConfig.ts
@@ -1,14 +1,15 @@
+import { ProjectDescription } from "../initializeProject/shared";
 import { InitializationImports } from "./imports";
 import { InitializationRenames } from "./renames";
 
 export interface JavaScriptConfigSettings {
     imports: InitializationImports;
-    project: string;
+    project: ProjectDescription;
     renames: InitializationRenames;
     sourceFiles?: string;
 }
 
-export const createJavaScriptConfig = async ({ imports, project, sourceFiles, renames }: JavaScriptConfigSettings) => {
+export const createJavaScriptConfig = ({ imports, project, sourceFiles, renames }: JavaScriptConfigSettings) => {
     const fileConversion = {
         files: {
             renameExtensions: printRenames(renames),
@@ -23,7 +24,7 @@ export const createJavaScriptConfig = async ({ imports, project, sourceFiles, re
     };
     const shared = (include: string[] | undefined) => ({
         ...(include && { include }),
-        project,
+        project: project.filePath,
     });
 
     const allConversions =

--- a/src/initialization/initializeJavaScript/index.ts
+++ b/src/initialization/initializeJavaScript/index.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "mz/fs";
 
+import { ProjectDescription } from "../initializeProject/shared";
 import { initializeSources } from "../sources";
 import { initializeImports } from "./imports";
 import { initializeRenames } from "./renames";
@@ -7,14 +8,14 @@ import { createJavaScriptConfig } from "./createJavaScriptConfig";
 
 export interface InitializeJavaScriptSettings {
     fileName: string;
-    project: string;
+    project: ProjectDescription;
 }
 
 export const initializeJavaScript = async ({ fileName, project }: InitializeJavaScriptSettings) => {
-    const sourceFiles = await initializeSources({ fromJavaScript: true });
+    const sourceFiles = await initializeSources({ fromJavaScript: true, project });
     const renames = await initializeRenames();
     const imports = await initializeImports();
 
-    const settings = await createJavaScriptConfig({ imports, project, sourceFiles, renames });
+    const settings = createJavaScriptConfig({ imports, project, sourceFiles, renames });
     await writeFile(fileName, JSON.stringify(settings, undefined, 4));
 };

--- a/src/initialization/initializeProject/initializeNewProject.ts
+++ b/src/initialization/initializeProject/initializeNewProject.ts
@@ -1,0 +1,78 @@
+import { fs } from "mz";
+import { prompt } from "enquirer";
+import { ProjectDescription } from "./shared";
+
+const filePath = "./tsconfig.json";
+
+export const initializeNewProject = async (): Promise<ProjectDescription> => {
+    const { emit } = await prompt<{ emit: string }>([
+        {
+            choices: ["yes", "no"],
+            message: "Should TypeScript output .js files from .ts sources?",
+            name: "emit",
+            type: "select",
+        },
+    ]);
+    const { inBrowser } = await prompt<{ inBrowser: string }>([
+        {
+            choices: ["yes", "no"],
+            message: "Does your code run in browser?",
+            name: "inBrowser",
+            type: "select",
+        },
+    ]);
+    const jsx =
+        inBrowser &&
+        (
+            await prompt<{ jsx: string }>([
+                {
+                    choices: ["yes", "no"],
+                    message: "Does your project use JSX?",
+                    name: "jsx",
+                    type: "select",
+                },
+            ])
+        ).jsx;
+    const { target } = await prompt<{ target: string }>([
+        {
+            choices: ["es2020", "es2021", "es2022", "esnext"],
+            message: "What minimum runtime does your code run on?",
+            name: "target",
+            type: "select",
+        },
+    ]);
+    const { strict } = await prompt<{ strict: string }>([
+        {
+            choices: ["yes", "no"],
+            message: "Would you like to enable TypeScript's strict compiler options? (recommended)",
+            name: "strict",
+            type: "select",
+        },
+    ]);
+
+    await fs.writeFile(
+        filePath,
+        JSON.stringify(
+            {
+                compilerOptions: {
+                    declaration: true,
+                    declarationMap: true,
+                    ...(emit === "no" && { noEmit: true }),
+                    esModuleInterop: true,
+                    ...(inBrowser === "no" && { lib: [target] }),
+                    ...(jsx === "yes" && { jsx: "react" }),
+                    sourceMap: true,
+                    moduleResolution: "node",
+                    module: "nodenext",
+                    skipLibCheck: true,
+                    ...(strict === "yes" ? { strict: true } : {}),
+                    target,
+                },
+            },
+            null,
+            4,
+        ),
+    );
+
+    return { created: true, filePath };
+};

--- a/src/initialization/initializeProject/shared.ts
+++ b/src/initialization/initializeProject/shared.ts
@@ -1,0 +1,14 @@
+export enum TSConfigLocationSuggestion {
+    Custom = "custom",
+    DoesNotExist = "I don't have one yet",
+}
+
+export enum TSConfigLocation {
+    Root = "./tsconfig.json",
+    UnderSrc = "./src/tsconfig.json",
+}
+
+export interface ProjectDescription {
+    created?: boolean;
+    filePath: string;
+}

--- a/src/initialization/initializeTypeScript/index.ts
+++ b/src/initialization/initializeTypeScript/index.ts
@@ -1,5 +1,6 @@
 import { initializeSources } from "../sources";
 
+import { ProjectDescription } from "../initializeProject/shared";
 import { InitializationImprovement, initializeImprovements } from "./improvements";
 import { initializeTests } from "./initializeTests";
 import { writeMultiTypeScriptConfig } from "./writeMultiTypeScriptConfig";
@@ -7,12 +8,12 @@ import { writeSingleTypeScriptConfig } from "./writeSingleTypeScriptConfig";
 
 export interface InitializeTypeScriptSettings {
     fileName: string;
-    project: string;
+    project: ProjectDescription;
 }
 
 export const initializeTypeScript = async ({ fileName, project }: InitializeTypeScriptSettings) => {
     const improvements = new Set(await initializeImprovements());
-    const sourceFiles = await initializeSources({ fromJavaScript: false });
+    const sourceFiles = await initializeSources({ fromJavaScript: false, project });
 
     if (!improvements.has(InitializationImprovement.StrictNullChecks)) {
         await writeSingleTypeScriptConfig({ fileName, improvements, project, sourceFiles });

--- a/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
+++ b/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
@@ -1,11 +1,12 @@
 import { fs } from "mz";
+import { ProjectDescription } from "../initializeProject/shared";
 
 import { InitializationImprovement } from "./improvements";
 
 export interface MultiTypeScriptConfigSettings {
     fileName: string;
     improvements: ReadonlySet<InitializationImprovement>;
-    project: string;
+    project: ProjectDescription;
     sourceFiles?: string;
     testFiles: string;
 }
@@ -27,18 +28,21 @@ export const writeMultiTypeScriptConfig = async ({
                         strictNonNullAssertions: true,
                     },
                     include: [testFiles],
-                    projectPath: project,
+                    projectPath: project.filePath,
+                    types: {
+                        strictNullChecks: true,
+                    },
                 },
                 {
                     exclude: [testFiles],
                     fixes: printImprovements(improvements),
                     ...(sourceFiles && { include: [sourceFiles] }),
-                    projectPath: project,
+                    projectPath: project.filePath,
                 },
                 {
                     fixes: printImprovements(improvements),
                     include: [testFiles, sourceFiles],
-                    projectPath: project,
+                    projectPath: project.filePath,
                 },
             ],
             undefined,

--- a/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.ts
+++ b/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.ts
@@ -1,10 +1,11 @@
 import { fs } from "mz";
 
+import { ProjectDescription } from "../initializeProject/shared";
 import { InitializationImprovement } from "./improvements";
 
 export interface SingleTypeScriptConfigSettings {
     fileName: string;
-    project: string;
+    project: ProjectDescription;
     improvements: ReadonlySet<InitializationImprovement>;
     sourceFiles?: string;
 }
@@ -16,7 +17,7 @@ export const writeSingleTypeScriptConfig = async ({ fileName, project, sourceFil
             {
                 fixes: printImprovements(improvements),
                 ...(sourceFiles && { include: [sourceFiles] }),
-                projectPath: project,
+                projectPath: project.filePath,
             },
             undefined,
             4,


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1003
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

The CLI now includes an option for `I don't have one yet` in the `Where is your tsconfig.json?` question. Under that option, it'll ask a few questions about compiler options.

`project` settings afterwards also now remember whether the project was created by this process, so after you select an include path, it'll add an `include` to that `tsconfig.json`.

```plaintext
✔ What are you trying to accomplish? · Convert my JavaScript files to TypeScript
✔ Where is your tsconfig.json? · I don't have one yet
✔ Should TypeScript output .js files from .ts sources? · yes
✔ Does your code run in browser? · yes
✔ Does your project use JSX? · yes
✔ What minimum runtime does your code run on? · es2020
✔ Would you like to enable TypeScript's strict compiler options? (recommended) · yes
```
