### PR TITLE
1048: added option for no tests

### DIFF
--- a/src/initialization/initializeTypeScript/initializeTests.ts
+++ b/src/initialization/initializeTypeScript/initializeTests.ts
@@ -16,7 +16,7 @@ const initializeBuiltInTests = async () => {
         "src/**/__tests__/*.test.{ts,tsx}",
         "src/**/*.test.{ts,tsx}",
         "test/**/*.{ts,tsx}",
-        "none",
+        "(none)",
     ];
 
     const { testFiles } = await prompt<{ testFiles: string }>([

--- a/src/initialization/initializeTypeScript/initializeTests.ts
+++ b/src/initialization/initializeTypeScript/initializeTests.ts
@@ -1,10 +1,11 @@
 import { prompt } from "enquirer";
 
 const other = "other";
+const none = "none";
 
 export const initializeTests = async () => {
     const builtIn = await initializeBuiltInTests();
-    if (builtIn === "none") return;
+    if (builtIn === none) return;
 
     return builtIn === other ? getCustomTests() : builtIn;
 };

--- a/src/initialization/initializeTypeScript/initializeTests.ts
+++ b/src/initialization/initializeTypeScript/initializeTests.ts
@@ -1,7 +1,7 @@
 import { prompt } from "enquirer";
 
 const other = "other";
-const none = "none";
+const none = "(none)";
 
 export const initializeTests = async () => {
     const builtIn = await initializeBuiltInTests();
@@ -17,7 +17,7 @@ const initializeBuiltInTests = async () => {
         "src/**/__tests__/*.test.{ts,tsx}",
         "src/**/*.test.{ts,tsx}",
         "test/**/*.{ts,tsx}",
-        "(none)",
+        none,
     ];
 
     const { testFiles } = await prompt<{ testFiles: string }>([

--- a/src/initialization/initializeTypeScript/initializeTests.ts
+++ b/src/initialization/initializeTypeScript/initializeTests.ts
@@ -4,6 +4,7 @@ const other = "other";
 
 export const initializeTests = async () => {
     const builtIn = await initializeBuiltInTests();
+    if (builtIn === "none") return;
 
     return builtIn === other ? getCustomTests() : builtIn;
 };
@@ -15,6 +16,7 @@ const initializeBuiltInTests = async () => {
         "src/**/__tests__/*.test.{ts,tsx}",
         "src/**/*.test.{ts,tsx}",
         "test/**/*.{ts,tsx}",
+        "none",
     ];
 
     const { testFiles } = await prompt<{ testFiles: string }>([

--- a/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
+++ b/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
@@ -8,7 +8,7 @@ export interface MultiTypeScriptConfigSettings {
     improvements: ReadonlySet<InitializationImprovement>;
     project: ProjectDescription;
     sourceFiles?: string;
-    testFiles: string;
+    testFiles?: string;
 }
 
 export const writeMultiTypeScriptConfig = async ({
@@ -27,21 +27,21 @@ export const writeMultiTypeScriptConfig = async ({
                         ...printImprovements(improvements),
                         strictNonNullAssertions: true,
                     },
-                    include: [testFiles],
+                    ...(testFiles && { include: [testFiles] }),
                     projectPath: project.filePath,
                     types: {
                         strictNullChecks: true,
                     },
                 },
                 {
-                    exclude: [testFiles],
+                    ...(testFiles && { exclude: [testFiles] }),
                     fixes: printImprovements(improvements),
                     ...(sourceFiles && { include: [sourceFiles] }),
                     projectPath: project.filePath,
                 },
                 {
                     fixes: printImprovements(improvements),
-                    include: [testFiles, sourceFiles],
+                    ...(testFiles ? { include: [testFiles, sourceFiles] } : { include: [sourceFiles] }),
                     projectPath: project.filePath,
                 },
             ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to TypeStat! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1048
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview
If the user does not have test files, he/she can skip the question `Which glob matches your test files?` with an option of `none`.

<!-- Brief description of what is changed and how the code change does that. -->
