### PR TITLE
feat: add post-fix cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ To get a deeper understanding of TypeStat, read the following docs pages in orde
 
 1. **[Usage.md](./docs/Usage.md)** for an explanation of how TypeStat works
 2. **[Fixes.md](./docs/Fixes.md)** for the type of fixes TypeStat will generate mutations for
-3. **[Types.md](./docs/Types.md)** for configuring how to work with types in mutations
-4. **[Filters.md](./docs/Filters.md)** for using [tsquery](https://github.com/phenomnomnominal/tsquery) to ignore sections of source files
-5. **[Custom Mutators.md](./docs/Custom%20Mutators.md)** for including or creating custom mutators
+3. **[Cleanups.md](./docs/Cleanups.md)** for the post-fix cleaning TypeStat may apply to files
+4. **[Types.md](./docs/Types.md)** for configuring how to work with types in mutations
+5. **[Filters.md](./docs/Filters.md)** for using [tsquery](https://github.com/phenomnomnominal/tsquery) to ignore sections of source files
+6. **[Custom Mutators.md](./docs/Custom%20Mutators.md)** for including or creating custom mutators
 
 ## Development
 

--- a/docs/Cleanups.md
+++ b/docs/Cleanups.md
@@ -1,0 +1,23 @@
+# Cleanups
+
+After TypeStat has applied all the fixes it can to files, there may still be some general cleanups that need to be applied.
+Most commonly, any remaining TypeScript type errors may need to be suppressed with `// @ts-expect-error`.
+
+Each classification of cleanups can be individually configured in your `typestat.json` file.
+These all default to `false` but can be enabled by being set to `true`.
+
+```json
+{
+    "cleanups": {
+        "suppressTypeErrors": true
+    }
+}
+```
+
+## Cleaners
+
+### `suppressTypeErrors`
+
+Whether to add a `// @ts-expect-error` comment directive before each remaining type error.
+
+See [suppressTypeErrors/README.md](../src/cleanups/builtin/suppressTypeErrors/README.md).

--- a/src/cleanups/builtin/suppressTypeErrors/README.md
+++ b/src/cleanups/builtin/suppressTypeErrors/README.md
@@ -1,0 +1,26 @@
+# `suppressTypeErrors`
+
+Whether to add a `// @ts-expect-error` comment directive before each remaining type error.
+
+## Use Cases
+
+* Your existing code has type errors that are too complex or context-dependent for TypeStat to clean up.
+
+## Configuration
+
+```json
+{
+    "cleanups": {
+        "suppressTypeErrors": true
+    }
+}
+```
+
+## Mutations
+
+For each type error still remaining in files, a `// @ts-expect-error` comment will be added with the text of the error:
+
+```diff
++ // @ts-expect-error: Type 'number' is not assignable to type 'string'.
+let incorrect: string = 0;
+```

--- a/src/cleanups/builtin/suppressTypeErrors/index.ts
+++ b/src/cleanups/builtin/suppressTypeErrors/index.ts
@@ -6,17 +6,9 @@ import {
     isDiagnosticWithStart,
     stringifyDiagnosticMessageText,
 } from "../../../shared/diagnostics";
-import { TypeStatOptions } from "../../../options/types";
-import { LanguageServices } from "../../../services/language";
-import { Mutation } from "automutate";
+import { FileMutator } from "../../../shared/fileMutator";
 
-export interface SuppressionRequest {
-    readonly options: TypeStatOptions;
-    readonly services: LanguageServices;
-    readonly sourceFile: ts.SourceFile;
-}
-
-export const suppressRemainingTypeIssues = (request: SuppressionRequest): ReadonlyArray<Mutation> | undefined => {
+export const suppressRemainingTypeIssues: FileMutator = (request) => {
     if (!request.options.cleanups.suppressTypeErrors) {
         return undefined;
     }

--- a/src/cleanups/builtin/suppressTypeErrors/index.ts
+++ b/src/cleanups/builtin/suppressTypeErrors/index.ts
@@ -1,0 +1,52 @@
+import * as ts from "typescript";
+
+import {
+    DiagnosticWithStart,
+    getLineForDiagnostic,
+    isDiagnosticWithStart,
+    stringifyDiagnosticMessageText,
+} from "../../../shared/diagnostics";
+import { TypeStatOptions } from "../../../options/types";
+import { LanguageServices } from "../../../services/language";
+import { Mutation } from "automutate";
+
+export interface SuppressionRequest {
+    readonly options: TypeStatOptions;
+    readonly services: LanguageServices;
+    readonly sourceFile: ts.SourceFile;
+}
+
+export const suppressRemainingTypeIssues = (request: SuppressionRequest): ReadonlyArray<Mutation> | undefined => {
+    if (!request.options.cleanups.suppressTypeErrors) {
+        return undefined;
+    }
+
+    const allDiagnostics = request.services.program.getSemanticDiagnostics(request.sourceFile).filter(isDiagnosticWithStart);
+    if (!allDiagnostics.length) {
+        return undefined;
+    }
+
+    const diagnosticsPerLine = new Map<number, DiagnosticWithStart[]>();
+
+    for (const diagnostic of allDiagnostics) {
+        const line = getLineForDiagnostic(diagnostic, request.sourceFile);
+        const existing = diagnosticsPerLine.get(line);
+
+        if (existing) {
+            existing.push(diagnostic);
+        } else {
+            diagnosticsPerLine.set(line, [diagnostic]);
+        }
+    }
+
+    return Array.from(diagnosticsPerLine).map(([line, diagnostics]) => {
+        const messages = diagnostics.map(stringifyDiagnosticMessageText).join(" ");
+        return {
+            insertion: `// @ts-expect-error -- TODO: ${messages}\n`,
+            range: {
+                begin: ts.getPositionOfLineAndCharacter(request.sourceFile, line, 0),
+            },
+            type: "text-insert",
+        };
+    });
+};

--- a/src/initialization/initializeJavaScript/cleanups.ts
+++ b/src/initialization/initializeJavaScript/cleanups.ts
@@ -1,0 +1,20 @@
+import { prompt } from "enquirer";
+
+export enum InitializationCleanups {
+    No = "No",
+    Yes = "Yes",
+}
+
+export const initializeCleanups = async () => {
+    const { cleanups } = await prompt<{ cleanups: InitializationCleanups }>([
+        {
+            choices: [InitializationCleanups.No, InitializationCleanups.Yes],
+            initial: 1,
+            message: "Would you like to suppress remaining type errors with // @ts-expect-error comments?",
+            name: "cleanups",
+            type: "select",
+        },
+    ]);
+
+    return cleanups;
+};

--- a/src/initialization/initializeJavaScript/createJavaScriptConfig.test.ts
+++ b/src/initialization/initializeJavaScript/createJavaScriptConfig.test.ts
@@ -1,6 +1,7 @@
 import { InitializationImports } from "./imports";
 import { InitializationRenames } from "./renames";
 import { createJavaScriptConfig } from "./createJavaScriptConfig";
+import { InitializationCleanups } from "./cleanups";
 
 describe(createJavaScriptConfig, () => {
     test.each([
@@ -12,6 +13,24 @@ describe(createJavaScriptConfig, () => {
             },
             name: "Basic",
             settings: {
+                cleanups: InitializationCleanups.No,
+                imports: InitializationImports.No,
+                project: {
+                    filePath: "tsconfig.json",
+                },
+                renames: InitializationRenames.TS,
+            },
+        },
+        {
+            expected: {
+                files: { renameExtensions: "ts" },
+                fixes: { incompleteTypes: true, missingProperties: true, noImplicitAny: true },
+                cleanups: { suppressTypeErrors: true },
+                project: "tsconfig.json",
+            },
+            name: "Basic with Suppressions",
+            settings: {
+                cleanups: InitializationCleanups.Yes,
                 imports: InitializationImports.No,
                 project: {
                     filePath: "tsconfig.json",
@@ -36,6 +55,7 @@ describe(createJavaScriptConfig, () => {
             name: "TS Renames (multiple sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
+                cleanups: InitializationCleanups.No,
                 project: {
                     filePath: "tsconfig.json",
                 },
@@ -60,6 +80,7 @@ describe(createJavaScriptConfig, () => {
             name: "TSX Renames (multiple sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
+                cleanups: InitializationCleanups.No,
                 project: {
                     filePath: "tsconfig.json",
                 },
@@ -74,6 +95,7 @@ describe(createJavaScriptConfig, () => {
             ],
             name: "Auto Renames (no sourceFiles)",
             settings: {
+                cleanups: InitializationCleanups.No,
                 imports: InitializationImports.Yes,
                 project: {
                     filePath: "tsconfig.json",
@@ -98,6 +120,7 @@ describe(createJavaScriptConfig, () => {
             name: "Auto Renames (single sourceFiles extension)",
             settings: {
                 imports: InitializationImports.Yes,
+                cleanups: InitializationCleanups.No,
                 project: {
                     filePath: "tsconfig.json",
                 },
@@ -122,6 +145,7 @@ describe(createJavaScriptConfig, () => {
             name: "Auto Renames (multiple sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
+                cleanups: InitializationCleanups.No,
                 project: {
                     filePath: "tsconfig.json",
                 },
@@ -146,6 +170,7 @@ describe(createJavaScriptConfig, () => {
             name: "Auto Renames (parenthesized sourceFiles extensions)",
             settings: {
                 imports: InitializationImports.Yes,
+                cleanups: InitializationCleanups.No,
                 project: {
                     filePath: "tsconfig.json",
                 },
@@ -153,8 +178,8 @@ describe(createJavaScriptConfig, () => {
                 sourceFiles: "src/**/*.js(x)",
             },
         },
-    ])("$name", async ({ expected, settings }) => {
-        const actual = await createJavaScriptConfig(settings);
+    ])("$name", ({ expected, settings }) => {
+        const actual = createJavaScriptConfig(settings);
 
         expect(actual).toEqual(expected);
     });

--- a/src/initialization/initializeJavaScript/createJavaScriptConfig.ts
+++ b/src/initialization/initializeJavaScript/createJavaScriptConfig.ts
@@ -1,26 +1,29 @@
 import { ProjectDescription } from "../initializeProject/shared";
 import { InitializationImports } from "./imports";
 import { InitializationRenames } from "./renames";
+import { InitializationCleanups } from "./cleanups";
 
 export interface JavaScriptConfigSettings {
+    cleanups: InitializationCleanups;
     imports: InitializationImports;
     project: ProjectDescription;
     renames: InitializationRenames;
     sourceFiles?: string;
 }
 
-export const createJavaScriptConfig = ({ imports, project, sourceFiles, renames }: JavaScriptConfigSettings) => {
+export const createJavaScriptConfig = ({ imports, project, sourceFiles, cleanups, renames }: JavaScriptConfigSettings) => {
     const fileConversion = {
         files: {
             renameExtensions: printRenames(renames),
         },
     };
-    const fixConversion = {
+    const coreConversion = {
         fixes: {
             incompleteTypes: true,
             missingProperties: true,
             noImplicitAny: true,
         },
+        ...(cleanups === InitializationCleanups.Yes ? { cleanups: { suppressTypeErrors: true } } : {}),
     };
     const shared = (include: string[] | undefined) => ({
         ...(include && { include }),
@@ -38,7 +41,7 @@ export const createJavaScriptConfig = ({ imports, project, sourceFiles, renames 
                       ...shared(sourceFiles ? [sourceFiles] : undefined),
                   },
                   {
-                      ...fixConversion,
+                      ...coreConversion,
                       ...shared(
                           sourceFiles
                               ? renames === InitializationRenames.Auto
@@ -52,7 +55,7 @@ export const createJavaScriptConfig = ({ imports, project, sourceFiles, renames 
               ]
             : {
                   ...fileConversion,
-                  ...fixConversion,
+                  ...coreConversion,
                   ...shared(sourceFiles ? [sourceFiles] : undefined),
               };
 

--- a/src/initialization/initializeJavaScript/index.ts
+++ b/src/initialization/initializeJavaScript/index.ts
@@ -5,6 +5,7 @@ import { initializeSources } from "../sources";
 import { initializeImports } from "./imports";
 import { initializeRenames } from "./renames";
 import { createJavaScriptConfig } from "./createJavaScriptConfig";
+import { initializeCleanups } from "./cleanups";
 
 export interface InitializeJavaScriptSettings {
     fileName: string;
@@ -15,7 +16,9 @@ export const initializeJavaScript = async ({ fileName, project }: InitializeJava
     const sourceFiles = await initializeSources({ fromJavaScript: true, project });
     const renames = await initializeRenames();
     const imports = await initializeImports();
+    const cleanups = await initializeCleanups();
 
-    const settings = createJavaScriptConfig({ imports, project, sourceFiles, renames });
+    const settings = createJavaScriptConfig({ imports, project, sourceFiles, cleanups, renames });
+
     await writeFile(fileName, JSON.stringify(settings, undefined, 4));
 };

--- a/src/mutations/aliasing/aliases.ts
+++ b/src/mutations/aliasing/aliases.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 
 /**
  * Type flags and aliases to check when --strictNullChecks is not enabled.

--- a/src/mutations/aliasing/joinIntoType.ts
+++ b/src/mutations/aliasing/joinIntoType.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { isNotUndefined, uniquify } from "../../shared/arrays";
 import { getApplicableTypeAliases } from "./aliases";
 

--- a/src/mutations/assignments.ts
+++ b/src/mutations/assignments.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "../shared/fileMutator";
 import { getTypeAtLocationIfNotError } from "../shared/types";
 
 export interface AssignedTypeValue {

--- a/src/mutations/codeFixes/addMissingProperty.ts
+++ b/src/mutations/codeFixes/addMissingProperty.ts
@@ -1,7 +1,7 @@
 import { Mutation } from "automutate";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 
 import { createCodeFixCreationMutation } from "./creation";
 

--- a/src/mutations/codeFixes/creation.ts
+++ b/src/mutations/codeFixes/creation.ts
@@ -1,6 +1,6 @@
 import { combineMutations, MultipleMutations, TextInsertMutation } from "automutate";
 import * as ts from "typescript";
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 
 export interface CodeFixCreationPreferences {
     ignoreKnownBlankTypes?: boolean;

--- a/src/mutations/codeFixes/getCodeFixIfMatchedByDiagnostic.ts
+++ b/src/mutations/codeFixes/getCodeFixIfMatchedByDiagnostic.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 
 /**
  * Uses a requesting language service to get code fixes for a type of node.

--- a/src/mutations/codeFixes/noImplicitAny.ts
+++ b/src/mutations/codeFixes/noImplicitAny.ts
@@ -2,7 +2,7 @@ import { Mutation } from "automutate";
 import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { getTypeAtLocationIfNotError } from "../../shared/types";
 
 import { createCodeFixCreationMutation } from "./creation";

--- a/src/mutations/codeFixes/noImplicitThis.ts
+++ b/src/mutations/codeFixes/noImplicitThis.ts
@@ -1,7 +1,7 @@
 import { Mutation } from "automutate";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 
 import { createCodeFixCreationMutation } from "./creation";
 import { getCodeFixIfMatchedByDiagnostic } from "./getCodeFixIfMatchedByDiagnostic";

--- a/src/mutations/collecting.ts
+++ b/src/mutations/collecting.ts
@@ -1,7 +1,7 @@
 import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "../shared/fileMutator";
 import { isKnownGlobalBaseType } from "../shared/nodeTypes";
 import { setSubtract } from "../shared/sets";
 

--- a/src/mutations/creations/creationMutations.ts
+++ b/src/mutations/creations/creationMutations.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { printNewLine } from "../../shared/printing/newlines";
 import { printNamedTypeSummaries } from "../../shared/printing/nodePrinting";
 import { TypeSummariesByName } from "../expansions/summarization";

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -2,7 +2,7 @@ import { TextInsertMutation, TextSwapMutation } from "automutate";
 import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "../shared/fileMutator";
 import { isKnownGlobalBaseType, NodeWithAddableType, NodeWithCreatableType } from "../shared/nodeTypes";
 
 import { joinIntoType } from "./aliasing/joinIntoType";

--- a/src/mutations/expansions/addIncompleteTypesToType.ts
+++ b/src/mutations/expansions/addIncompleteTypesToType.ts
@@ -1,7 +1,7 @@
 import { combineMutations, MultipleMutations, Mutation, TextInsertMutation, TextSwapMutation } from "automutate";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { isKnownGlobalBaseType, isNeverAndOrUnknownType, PropertySignatureWithType } from "../../shared/nodeTypes";
 
 import { TypeSummary } from "./summarization";

--- a/src/mutations/expansions/addMissingTypesToType.ts
+++ b/src/mutations/expansions/addMissingTypesToType.ts
@@ -1,7 +1,7 @@
 import { TextInsertMutation } from "automutate";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { printNamedTypeSummary } from "../../shared/printing/nodePrinting";
 
 import { TypeSummariesByName } from "./summarization";

--- a/src/mutations/expansions/eliminations.ts
+++ b/src/mutations/expansions/eliminations.ts
@@ -1,7 +1,7 @@
 import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { isKnownGlobalBaseType, isNeverAndOrUnknownType } from "../../shared/nodeTypes";
 
 const onlyTypes = (candidateTypes: ReadonlyArray<ts.Type | string>): candidateTypes is ReadonlyArray<ts.Type> =>

--- a/src/mutations/expansions/expansionMutations.ts
+++ b/src/mutations/expansions/expansionMutations.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { AssignedTypesByName } from "../assignments";
 import { InterfaceOrTypeLiteral } from "../../mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/collectGenericNodeReferences";
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { isNotUndefined } from "../../shared/arrays";
 import { getStaticNameOfProperty } from "../../shared/names";
 

--- a/src/mutations/expansions/summarization.ts
+++ b/src/mutations/expansions/summarization.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 import { AssignedTypesByName } from "../assignments";
 
 export type TypeSummariesByName = Map<string, TypeSummary>;

--- a/src/mutations/generics.ts
+++ b/src/mutations/generics.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "../shared/fileMutator";
 import { isTypeBuiltIn } from "../shared/types";
 
 import { constructArrayShorthand } from "./arrays";

--- a/src/mutations/naming.ts
+++ b/src/mutations/naming.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "../shared/fileMutator";
 
 export const isUpperCaseLetter = (letter: string) => {
     return letter !== letter.toLowerCase();

--- a/src/mutations/removals.ts
+++ b/src/mutations/removals.ts
@@ -1,7 +1,7 @@
 import { TextDeleteMutation } from "automutate";
 
 import { NodeWithType } from "../shared/nodeTypes";
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "../shared/fileMutator";
 
 export const createTypeRemovalMutation = (request: FileMutationsRequest, node: NodeWithType): TextDeleteMutation => {
     return {

--- a/src/mutations/typeMutating/createNonNullAssertion.ts
+++ b/src/mutations/typeMutating/createNonNullAssertion.ts
@@ -1,7 +1,7 @@
 import { TextInsertMutation, TextSwapMutation } from "automutate";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../../shared/fileMutator";
 
 // The following node types need to be wrapped in parenthesis to stop the ! from being applied to the wrong (last) element:
 // As expressions: foo as Bar

--- a/src/mutators/builtIn/fixImportExtensions/index.ts
+++ b/src/mutators/builtIn/fixImportExtensions/index.ts
@@ -5,7 +5,7 @@ import * as ts from "typescript";
 
 import { getTypeAtLocationIfNotError } from "../../../shared/types";
 import { collectMutationsFromNodes } from "../../collectMutationsFromNodes";
-import { FileMutator, FileMutationsRequest } from "../../fileMutator";
+import { FileMutator, FileMutationsRequest } from "../../../shared/fileMutator";
 
 type ExtensionlessExportOrImport = (ts.ExportDeclaration | ts.ImportDeclaration) & {
     moduleSpecifier: ts.StringLiteral;

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/additions.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/additions.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 import { printNewLine } from "../../../../shared/printing/newlines";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 
 export const addNewTypeNodes = (request: FileMutationsRequest, node: ts.ClassLikeDeclaration, createdTypes: string[]) => {
     const endline = printNewLine(request.options.compilerOptions);

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/collectTypeParameterReferences.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/collectTypeParameterReferences.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 
 import { isNotUndefined } from "../../../../shared/arrays";
 import { getCloseAncestorCallOrNewExpression, getExpressionWithin } from "../../../../shared/nodes";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 
 /**
  * Finds all the nodes that could indicate the type of a base type parameter,

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitClassGenerics/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitClassGenerics/index.ts
@@ -4,7 +4,7 @@ import * as ts from "typescript";
 import { isNotUndefined } from "../../../../../shared/arrays";
 import { getBaseClassDeclaration, getClassExtendsExpression } from "../../../../../shared/nodeExtensions";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../../shared/fileMutator";
 import { addMissingTemplateTypes, addNewTypeNodes } from "../additions";
 import { findMissingTemplateTypes } from "../templateCollecting";
 import { fillInMissingTemplateTypes } from "../templateMutating";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/collectGenericUses.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/collectGenericUses.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import { getTypeAtLocationIfNotError } from "../../../../../shared/types";
 
-import { FileMutationsRequest } from "../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../shared/fileMutator";
 
 import { GenericClassDetails } from "./getGenericClassDetails";
 import { VariableWithImplicitGeneric } from "./implicitGenericTypes";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/createExplicitGenericType.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/createExplicitGenericType.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { joinIntoGenericType } from "../../../../../mutations/generics";
 import { isTypeArgumentsType } from "../../../../../shared/typeNodes";
-import { FileMutationsRequest } from "../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../shared/fileMutator";
 
 import { GenericClassDetails } from "./getGenericClassDetails";
 import { VariableWithImplicitGeneric } from "./implicitGenericTypes";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/getGenericClassDetails.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/getGenericClassDetails.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 import { getTypeAtLocationIfNotError, typeHasLocalTypeParameters } from "../../../../../shared/types";
-import { FileMutationsRequest } from "../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../shared/fileMutator";
 
 import { VariableWithImplicitGeneric } from "./implicitGenericTypes";
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/index.ts
@@ -1,5 +1,5 @@
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../../shared/fileMutator";
 
 import { collectGenericUses } from "./collectGenericUses";
 import { createExplicitGenericType } from "./createExplicitGenericType";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/index.ts
@@ -1,5 +1,5 @@
 import { findFirstMutations } from "../../../../shared/runtime";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 import { fixIncompleteImplicitClassGenerics } from "./fixIncompleteImplicitClassGenerics";
 import { fixIncompleteImplicitVariableGenerics } from "./fixIncompleteImplicitVariableGenerics";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateCollecting.ts
@@ -5,7 +5,7 @@ import { getCallExpressionType } from "../../../../shared/calls";
 import { getStaticNameOfProperty } from "../../../../shared/names";
 import { isNodeAssigningBinaryExpression, isNodeWithinNode } from "../../../../shared/nodes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 
 import { collectTypeParameterReferences } from "./collectTypeParameterReferences";
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateMutating.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/templateMutating.ts
@@ -5,7 +5,7 @@ import { createDeclarationForTypeSummaries } from "../../../../mutations/creatio
 import { summarizeAllAssignedTypes } from "../../../../mutations/expansions/summarization";
 import { getFriendlyTypeParameterDeclarationName, getPerceivedNameOfClass } from "../../../../mutations/naming";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 
 export const fillInMissingTemplateTypes = (
     request: FileMutationsRequest,

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/collectGenericNodeReferences.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/collectGenericNodeReferences.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../shared/nodeTypes";
 import { isTypeArgumentsType } from "../../../../shared/typeNodes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 
 export type InterfaceOrTypeLiteral = ts.InterfaceDeclaration | ts.TypeLiteralNode;
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/expandValuesAssignedToReferenceNodes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/expandValuesAssignedToReferenceNodes.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 import { AssignedTypeValue } from "../../../../mutations/assignments";
 import { isNodeAssigningBinaryExpression } from "../../../../shared/nodes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 
 export const expandValuesAssignedToReferenceNodes = (
     request: FileMutationsRequest,

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteInterfaceOrTypeLiteralGenerics/index.ts
@@ -5,7 +5,7 @@ import { joinAssignedTypesByName } from "../../../../mutations/assignments";
 import { createTypeExpansionMutation } from "../../../../mutations/expansions/expansionMutations";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 import { collectGenericNodeReferences, InterfaceOrTypeLiteral } from "./collectGenericNodeReferences";
 import { expandValuesAssignedToReferenceNodes } from "./expandValuesAssignedToReferenceNodes";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteParameterTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteParameterTypes/index.ts
@@ -5,7 +5,7 @@ import { createTypeAdditionMutation, createTypeCreationMutation } from "../../..
 import { isNodeWithType, NodeWithType } from "../../../../shared/nodeTypes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixIncompleteParameterTypes: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> =>
     collectMutationsFromNodes(request, isParameterWithType, visitParameterDeclaration);

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
@@ -7,7 +7,7 @@ import { isNodeAssigningBinaryExpression } from "../../../../shared/nodes";
 import { isNodeWithType, NodeWithType } from "../../../../shared/nodeTypes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixIncompletePropertyDeclarationTypes: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> =>
     collectMutationsFromNodes(request, isPropertyDeclarationWithType, visitPropertyDeclaration);

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/collectAllFunctionCallTypes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/collectAllFunctionCallTypes.ts
@@ -4,7 +4,7 @@ import { getDeclaredTypesOfArgument } from "../../../../../shared/calls";
 import { isPropertySignatureWithStaticName, PropertySignatureWithStaticName } from "../../../../../shared/nodeTypes";
 import { getTypeAtLocationIfNotError } from "../../../../../shared/types";
 
-import { FileMutationsRequest } from "../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../shared/fileMutator";
 import { ReactComponentPropsNode } from "../getComponentPropsNode";
 import { getPropNodeFromReference } from "../getPropNodeFromReference";
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/createFunctionCallTypesMutation.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/createFunctionCallTypesMutation.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { collectOptionals, isNotUndefined } from "../../../../../shared/arrays";
 import { PropertySignatureWithStaticName } from "../../../../../shared/nodeTypes";
-import { FileMutationsRequest } from "../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../shared/fileMutator";
 import { FunctionCallType } from "./collectAllFunctionCallTypes";
 
 type CombinedFunctionType = {

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropFunctionsFromCalls/index.ts
@@ -1,5 +1,5 @@
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../../shared/fileMutator";
 import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 import { getComponentPropsNode } from "../getComponentPropsNode";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/getComponentAssignedTypesFromUsage.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 import { AssignedTypesByName } from "../../../../../mutations/assignments";
 import { getStaticNameOfProperty } from "../../../../../shared/names";
 import { getTypeAtLocationIfNotError } from "../../../../../shared/types";
-import { FileMutationsRequest } from "../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../shared/fileMutator";
 import { ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 /**

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromLaterAssignments/index.ts
@@ -1,6 +1,6 @@
 import { createTypeExpansionMutation } from "../../../../../mutations/expansions/expansionMutations";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../../shared/fileMutator";
 import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 import { getComponentAssignedTypesFromUsage } from "./getComponentAssignedTypesFromUsage";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/index.ts
@@ -5,7 +5,7 @@ import { ReactPropTypesHint } from "../../../../../options/enums";
 import { getClassExtendsType } from "../../../../../shared/nodes";
 import { printNewLine } from "../../../../../shared/printing/newlines";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../../shared/fileMutator";
 import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 import { createInterfaceUsageMutation } from "./annotation/createInterfaceUsageMutation";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/createInterfaceFromPropTypes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/createInterfaceFromPropTypes.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../../shared/fileMutator";
 import { getApparentNameOfComponent } from "../../getApparentNameOfComponent";
 import { ReactComponentNode } from "../../reactFiltering/isReactComponentNode";
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/propTypesProperties.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/propTypesProperties.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 import { ReactPropTypesOptionality } from "../../../../../../options/enums";
-import { FileMutationsRequest } from "../../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../../shared/fileMutator";
 
 import { getPropTypesMember } from "./propTypesExtraction";
 import { createPropTypesTransform } from "./propTypesTransforms";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/propTypesTransforms.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/propTypesTransforms.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 import { KnownTypeLiteralNode, transformLiteralToTypeLiteralNode } from "../../../../../../shared/transforms";
-import { FileMutationsRequest } from "../../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../../shared/fileMutator";
 
 import { getPropTypesMember, PropTypesAccessNode, PropTypesMembers } from "./propTypesExtraction";
 import { createPropTypesProperty } from "./propTypesProperties";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromUses/getPropsUsageTypes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromUses/getPropsUsageTypes.ts
@@ -10,7 +10,7 @@ import {
     PropertySignatureWithStaticName,
 } from "../../../../../shared/nodeTypes";
 import { getSymbolAtLocationIfNotError, getTypeAtLocationIfNotError } from "../../../../../shared/types";
-import { FileMutationsRequest } from "../../../../fileMutator";
+import { FileMutationsRequest } from "../../../../../shared/fileMutator";
 import { getComponentPropsNode, ReactComponentPropsNode } from "../getComponentPropsNode";
 import { getPropNodeFromReference } from "../getPropNodeFromReference";
 import { getReactComponentNode } from "../reactFiltering/getReactComponentNode";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromUses/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromUses/index.ts
@@ -1,6 +1,6 @@
 import { createTypeExpansionMutation } from "../../../../../mutations/expansions/expansionMutations";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../../shared/fileMutator";
 import { isReactComponentNode, ReactComponentNode } from "../reactFiltering/isReactComponentNode";
 
 import { getComponentPropsNode } from "../getComponentPropsNode";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsMissing.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsMissing.ts
@@ -1,7 +1,7 @@
 import { combineMutations } from "automutate";
 import * as ts from "typescript";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 import { isReactComponentNode, ReactComponentNode } from "./reactFiltering/isReactComponentNode";
 import { getComponentPropsNode } from "./getComponentPropsNode";
 import { getApparentNameOfComponent } from "./getApparentNameOfComponent";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getApparentNameOfComponent.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getApparentNameOfComponent.ts
@@ -2,7 +2,7 @@ import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
 import { getFriendlyFileName } from "../../../../shared/fileNames";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 import { ReactComponentNode } from "./reactFiltering/isReactComponentNode";
 
 /**

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getComponentPropsNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/getComponentPropsNode.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 
 import { getClassExtendsType } from "../../../../shared/nodes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 import {
     ReactClassComponentNode,
     ReactComponentNode,

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/index.ts
@@ -1,5 +1,5 @@
 import { findFirstMutations } from "../../../../shared/runtime";
-import { FileMutationsRequest } from "../../../fileMutator";
+import { FileMutationsRequest } from "../../../../shared/fileMutator";
 
 import { fixReactPropsFromLaterAssignments } from "./fixReactPropsFromLaterAssignments";
 import { fixReactPropsFromUses } from "./fixReactPropsFromUses";

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
@@ -7,7 +7,7 @@ import { isNotUndefined } from "../../../../shared/arrays";
 import { FunctionLikeDeclarationWithType, isNodeWithType } from "../../../../shared/nodeTypes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 import { collectReturningNodeExpressions } from "../../fixStrictNonNullAssertions/fixStrictNonNullAssertionReturnTypes/collectReturningNodeExpressions";
 
 export const fixIncompleteReturnTypes: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> =>

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteVariableTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteVariableTypes/index.ts
@@ -7,7 +7,7 @@ import { isNodeWithType, NodeWithType } from "../../../../shared/nodeTypes";
 import { isNodeFilteredOut } from "../../../../shared/references";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixIncompleteVariableTypes: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> =>
     collectMutationsFromNodes(request, isNodeVariableDeclarationWithType, visitVariableDeclaration);

--- a/src/mutators/builtIn/fixIncompleteTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/index.ts
@@ -1,5 +1,5 @@
 import { findFirstMutations } from "../../../shared/runtime";
-import { FileMutationsRequest } from "../../fileMutator";
+import { FileMutationsRequest } from "../../../shared/fileMutator";
 
 import { fixIncompleteImplicitGenerics } from "./fixIncompleteImplicitGenerics";
 import { fixIncompleteInterfaceOrTypeLiteralGenerics } from "./fixIncompleteInterfaceOrTypeLiteralGenerics";

--- a/src/mutators/builtIn/fixMissingProperties/fixMissingPropertyAccesses/index.ts
+++ b/src/mutators/builtIn/fixMissingProperties/fixMissingPropertyAccesses/index.ts
@@ -4,7 +4,7 @@ import * as ts from "typescript";
 import { getMissingPropertyMutations } from "../../../../mutations/codeFixes/addMissingProperty";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixMissingPropertyAccesses: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> => {
     // If an undeclared property is referenced multiple times, TypeScript will suggest adding it in each time

--- a/src/mutators/builtIn/fixMissingProperties/index.ts
+++ b/src/mutators/builtIn/fixMissingProperties/index.ts
@@ -1,5 +1,5 @@
 import { findFirstMutations } from "../../../shared/runtime";
-import { FileMutationsRequest } from "../../fileMutator";
+import { FileMutationsRequest } from "../../../shared/fileMutator";
 
 import { fixMissingPropertyAccesses } from "./fixMissingPropertyAccesses";
 

--- a/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyParameters/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyParameters/index.ts
@@ -7,7 +7,7 @@ import {
     NoImplictAnyNodeToBeFixed,
 } from "../../../../mutations/codeFixes/noImplicitAny";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixNoImplicitAnyParameters: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> =>
     collectMutationsFromNodes(request, isNodeNoImplicitAnyFixableParameter, getNoImplicitAnyMutations);

--- a/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyPropertyDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyPropertyDeclarations/index.ts
@@ -7,7 +7,7 @@ import {
     NoImplictAnyNodeToBeFixed,
 } from "../../../../mutations/codeFixes/noImplicitAny";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixNoImplicitAnyPropertyDeclarations: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> =>
     collectMutationsFromNodes(request, isNodeNoImplicitAnyFixablePropertyDeclaration, getNoImplicitAnyMutations);

--- a/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyVariableDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyVariableDeclarations/index.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { canNodeBeFixedForNoImplicitAny, getNoImplicitAnyMutations } from "../../../../mutations/codeFixes/noImplicitAny";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixNoImplicitAnyVariableDeclarations: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> => {
     // This mutator fixes only for --noImplicitAny

--- a/src/mutators/builtIn/fixNoImplicitAny/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitAny/index.ts
@@ -1,5 +1,5 @@
 import { findFirstMutations } from "../../../shared/runtime";
-import { FileMutationsRequest } from "../../fileMutator";
+import { FileMutationsRequest } from "../../../shared/fileMutator";
 
 import { fixNoImplicitAnyParameters } from "./fixNoImplicitAnyParameters";
 import { fixNoImplicitAnyPropertyDeclarations } from "./fixNoImplicitAnyPropertyDeclarations";

--- a/src/mutators/builtIn/fixNoImplicitThis/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitThis/index.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 
 import { getNoImplicitThisMutations } from "../../../mutations/codeFixes/noImplicitThis";
 import { collectMutationsFromNodes } from "../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../shared/fileMutator";
 
 export const fixNoImplicitThis: FileMutator = (request: FileMutationsRequest) =>
     request.options.fixes.noImplicitThis ? collectMutationsFromNodes(request, isThisExpression, getNoImplicitThisMutations) : undefined;

--- a/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesParameters/index.ts
+++ b/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesParameters/index.ts
@@ -5,7 +5,7 @@ import { createTypeRemovalMutation } from "../../../../mutations/removals";
 import { declaredInitializedTypeNodeIsRedundant } from "../../../../shared/comparisons";
 import { ParameterDeclarationWithType, isNodeWithType } from "../../../../shared/nodeTypes";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixNoInferableTypesParameters: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> =>
     collectMutationsFromNodes(request, isInferableTypeCapableParameter, getNoInferableTypeParameterMutation);

--- a/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesPropertyDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesPropertyDeclarations/index.ts
@@ -5,7 +5,7 @@ import { createTypeRemovalMutation } from "../../../../mutations/removals";
 import { declaredInitializedTypeNodeIsRedundant } from "../../../../shared/comparisons";
 import { isNodeWithType, NodeWithType } from "../../../../shared/nodeTypes";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 type InferablePropertyDeclaration = ts.PropertyDeclaration & NodeWithType & Required<Pick<ts.PropertyDeclaration, "initializer">>;
 

--- a/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesVariableDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesVariableDeclarations/index.ts
@@ -6,7 +6,7 @@ import { createTypeRemovalMutation } from "../../../../mutations/removals";
 import { declaredInitializedTypeNodeIsRedundant } from "../../../../shared/comparisons";
 import { isNodeWithType, NodeWithType } from "../../../../shared/nodeTypes";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 type InferableVariableDeclaration = ts.VariableDeclaration &
     NodeWithType &

--- a/src/mutators/builtIn/fixNoInferableTypes/index.ts
+++ b/src/mutators/builtIn/fixNoInferableTypes/index.ts
@@ -1,5 +1,5 @@
 import { findFirstMutations } from "../../../shared/runtime";
-import { FileMutationsRequest } from "../../fileMutator";
+import { FileMutationsRequest } from "../../../shared/fileMutator";
 
 import { fixNoInferableTypesParameters } from "./fixNoInferableTypesParameters";
 import { fixNoInferableTypesPropertyDeclarations } from "./fixNoInferableTypesPropertyDeclarations";

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionBinaryExpressions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionBinaryExpressions/index.ts
@@ -7,7 +7,7 @@ import { createNonNullAssertion } from "../../../../mutations/typeMutating/creat
 import { isNodeAssigningBinaryExpression } from "../../../../shared/nodes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixStrictNonNullAssertionBinaryExpressions: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> => {
     return collectMutationsFromNodes(request, isNodeAssigningBinaryExpression, visitBinaryExpression);

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
@@ -9,7 +9,7 @@ import { getParentOfKind, getVariableInitializerForExpression } from "../../../.
 import { isNullOrUndefinedMissingBetween } from "../../../../shared/nodeTypes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixStrictNonNullAssertionCallExpressions: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> => {
     return collectMutationsFromNodes(request, isVisitableCallExpression, visitCallExpression);

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionObjectLiterals/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionObjectLiterals/index.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { createNonNullAssertion } from "../../../../mutations/typeMutating/createNonNullAssertion";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 import { getManuallyAssignedTypeOfNode } from "../../../../shared/assignments";
 import { getStaticNameOfProperty } from "../../../../shared/names";
 import { isNullOrUndefinedMissingBetween } from "../../../../shared/nodeTypes";

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionPropertyAccesses/index.ts
@@ -5,7 +5,7 @@ import { isTypeFlagSetRecursively } from "../../../../mutations/collecting/flags
 import { createNonNullAssertion } from "../../../../mutations/typeMutating/createNonNullAssertion";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 export const fixStrictNonNullAssertionPropertyAccesses: FileMutator = (request: FileMutationsRequest): ReadonlyArray<Mutation> => {
     const visitPropertyAccessExpression = (node: ts.PropertyAccessExpression): Mutation | undefined => {

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionReturnTypes/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionReturnTypes/index.ts
@@ -8,7 +8,7 @@ import { getVariableInitializerForExpression } from "../../../../shared/nodes";
 import { FunctionLikeDeclarationWithType, isNodeWithType } from "../../../../shared/nodeTypes";
 import { getTypeAtLocationIfNotError } from "../../../../shared/types";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes";
-import { FileMutationsRequest, FileMutator } from "../../../fileMutator";
+import { FileMutationsRequest, FileMutator } from "../../../../shared/fileMutator";
 
 import { collectReturningNodeExpressions } from "./collectReturningNodeExpressions";
 

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/index.ts
@@ -1,5 +1,5 @@
 import { findFirstMutations } from "../../../shared/runtime";
-import { FileMutationsRequest } from "../../fileMutator";
+import { FileMutationsRequest } from "../../../shared/fileMutator";
 
 import { fixStrictNonNullAssertionBinaryExpressions } from "./fixStrictNonNullAssertionBinaryExpressions";
 import { fixStrictNonNullAssertionCallExpressions } from "./fixStrictNonNullAssertionCallExpressions";

--- a/src/mutators/builtIn/index.ts
+++ b/src/mutators/builtIn/index.ts
@@ -1,4 +1,4 @@
-import { FileMutator } from "../fileMutator";
+import { FileMutator } from "../../shared/fileMutator";
 
 import { fixImportExtensions } from "./fixImportExtensions";
 import { fixIncompleteTypes } from "./fixIncompleteTypes";

--- a/src/mutators/collectMutationsFromNodes.ts
+++ b/src/mutators/collectMutationsFromNodes.ts
@@ -5,7 +5,7 @@ import * as ts from "typescript";
 import { getQuickErrorSummary } from "../shared/errors";
 import { NodeSelector } from "../shared/nodeTypes";
 
-import { FileMutationsRequest } from "./fileMutator";
+import { FileMutationsRequest } from "../shared/fileMutator";
 
 export type NodeVisitor<TNode extends ts.Node> = (node: TNode, request: FileMutationsRequest) => Readonly<Mutation> | undefined;
 

--- a/src/options/fillOutRawOptions.ts
+++ b/src/options/fillOutRawOptions.ts
@@ -76,6 +76,10 @@ export const fillOutRawOptions = ({
         package: packageOptions,
         postProcess: { shell },
         projectPath,
+        cleanups: {
+            suppressTypeErrors: false,
+            ...rawOptions.cleanups,
+        },
         types: {
             strictNullChecks: typeStrictNullChecks,
         },

--- a/src/options/parseRawCompilerOptions.ts
+++ b/src/options/parseRawCompilerOptions.ts
@@ -3,6 +3,7 @@ import { glob } from "glob";
 import * as fs from "mz/fs";
 import * as path from "path";
 import * as ts from "typescript";
+import { stringifyDiagnosticMessageText } from "../shared/diagnostics";
 
 export interface ParsedCompilerOptions extends ts.CompilerOptions {
     include?: string[];
@@ -12,13 +13,7 @@ export const parseRawCompilerOptions = async (cwd: string, projectPath: string):
     const configRaw = (await fs.readFile(projectPath)).toString();
     const compilerOptions = ts.parseConfigFileTextToJson(projectPath, configRaw);
     if (compilerOptions.error !== undefined) {
-        throw new Error(
-            `Could not parse compiler options from '${projectPath}': ${
-                typeof compilerOptions.error.messageText === "string"
-                    ? compilerOptions.error.messageText
-                    : compilerOptions.error.messageText.messageText
-            }`,
-        );
+        throw new Error(`Could not parse compiler options from '${projectPath}': ${stringifyDiagnosticMessageText(compilerOptions.error)}`);
     }
 
     const config = compilerOptions.config as ParsedCompilerOptions;

--- a/src/options/parsing/collectAddedMutators.ts
+++ b/src/options/parsing/collectAddedMutators.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 
 import { ProcessOutput } from "../../output/types";
 import { builtInFileMutators } from "../../mutators/builtIn";
-import { FileMutator } from "../../mutators/fileMutator";
+import { FileMutator } from "../../shared/fileMutator";
 import { collectOptionals } from "../../shared/arrays";
 import { getQuickErrorSummary } from "../../shared/errors";
 import { RawTypeStatOptions } from "../types";

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -21,7 +21,7 @@ export interface RawTypeStatOptions {
     readonly filters?: ReadonlyArray<string>;
 
     /**
-     * Which fixes (type mutations) are enabled, with fields defaulting to `true`.
+     * Which fixes (type mutations) are enabled.
      */
     readonly fixes?: Partial<Fixes>;
 
@@ -54,6 +54,11 @@ export interface RawTypeStatOptions {
      * Path to a TypeScript configuration file, if not "tsconfig.json".
      */
     readonly projectPath?: string;
+
+    /**
+     * Which post-run cleanups are enabled.
+     */
+    readonly cleanups?: Partial<Cleanups>;
 
     /**
      * Options for which types to add under what aliases.
@@ -124,6 +129,11 @@ export interface BaseTypeStatOptions {
      * Path to a tsconfig.json file.
      */
     readonly projectPath: string;
+
+    /**
+     * Whether each post-run cleanup is enabled.
+     */
+    readonly cleanups: Readonly<Cleanups>;
 
     /**
      * Options for which types to add under what aliases.
@@ -280,6 +290,16 @@ export interface PostProcess {
      * Shell commands to execute in order after mutations on mutated file paths.
      */
     shell: ReadonlyArray<ReadonlyArray<string>>;
+}
+
+/**
+ * Cleanups to run after fixing is done.
+ */
+export interface Cleanups {
+    /**
+     * Whether to suppress TypeScript type errors with comment directives.
+     */
+    suppressTypeErrors: boolean;
 }
 
 /**

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutator } from "../mutators/fileMutator";
+import { FileMutator } from "../shared/fileMutator";
 import { ProcessOutput } from "../output/types";
 import { ReactPropTypesHint, ReactPropTypesOptionality } from "./enums";
 

--- a/src/runtime/createTypeStatProvider.ts
+++ b/src/runtime/createTypeStatProvider.ts
@@ -9,6 +9,7 @@ import { createInstallMissingTypesProvider } from "./providers/createInstallMiss
 import { createMarkFilesModifiedProvider } from "./providers/createMarkFilesModifiedProvider";
 import { createPostProcessingProvider } from "./providers/createPostProcessingProvider";
 import { createRequireRenameProvider } from "./providers/createRequireRenameProvider";
+import { createCleanupsProvider } from "./providers/createCleanupsProvider";
 
 /**
  * Creates a mutations provider that mutates files, then marks them as mutated.
@@ -22,6 +23,7 @@ export const createTypeStatProvider = (options: TypeStatOptions): MutationsProvi
             createInstallMissingTypesProvider(),
             createRequireRenameProvider(allModifiedFiles),
             createCoreMutationsProvider(allModifiedFiles),
+            createCleanupsProvider(allModifiedFiles),
             createMarkFilesModifiedProvider(allModifiedFiles),
             createPostProcessingProvider(allModifiedFiles),
         ]),

--- a/src/runtime/findMutationsInFile.ts
+++ b/src/runtime/findMutationsInFile.ts
@@ -2,14 +2,17 @@ import { Mutation } from "automutate";
 import { EOL } from "os";
 
 import { MutationsComplaint } from "../mutators/complaint";
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest, FileMutator } from "../shared/fileMutator";
 import { findFirstMutations } from "../shared/runtime";
 
 /**
  * Collects all mutations that should apply to a file.
  */
-export const findMutationsInFile = (request: FileMutationsRequest): ReadonlyArray<Mutation> | undefined => {
-    let mutations = findFirstMutations(request, request.options.mutators);
+export const findMutationsInFile = (
+    request: FileMutationsRequest,
+    mutators: ReadonlyArray<[string, FileMutator]>,
+): ReadonlyArray<Mutation> | undefined => {
+    let mutations = findFirstMutations(request, mutators);
     if (mutations instanceof MutationsComplaint) {
         request.options.output.stderr(
             `${EOL}Error in ${request.sourceFile.fileName} with ${mutations.mutatorPath.join(" > ")}: ${

--- a/src/runtime/providers/createCleanupsProvider.ts
+++ b/src/runtime/providers/createCleanupsProvider.ts
@@ -1,0 +1,50 @@
+import { Mutation } from "automutate";
+
+import { convertMapToObject, Dictionary } from "../../shared/maps";
+import { createFileNamesAndServices } from "../createFileNamesAndServices";
+import { createSingleUseProvider } from "../createSingleUseProvider";
+import { suppressRemainingTypeIssues } from "../../cleanups/builtin/suppressTypeErrors";
+
+/**
+ * Creates a mutations provider that applies post-fix cleanups.
+ *
+ * @param allModifiedFileNames   Set to mark names of all files that were modified.
+ * @returns Provider to apply post-fix cleanups, if needed.
+ */
+export const createCleanupsProvider = (allModifiedFiles: Set<string>) => {
+    return createSingleUseProvider("Applying post-fix cleanups", (options) => {
+        if (!Object.values(options.cleanups).filter(Boolean).length) {
+            return undefined;
+        }
+
+        return () => {
+            const fileMutations = new Map<string, ReadonlyArray<Mutation>>();
+            const { fileNames, services } = createFileNamesAndServices(options);
+
+            for (const fileName of fileNames) {
+                const sourceFile = services.program.getSourceFile(fileName);
+                if (sourceFile === undefined) {
+                    options.output.stderr(`Could not find TypeScript source file for '${fileName}'.`);
+                    continue;
+                }
+
+                const foundMutations = suppressRemainingTypeIssues({
+                    options,
+                    services,
+                    sourceFile,
+                });
+
+                if (foundMutations?.length) {
+                    allModifiedFiles.add(fileName);
+                    fileMutations.set(fileName, foundMutations);
+                }
+            }
+
+            return {
+                mutationsWave: {
+                    fileMutations: fileMutations.size === 0 ? undefined : (convertMapToObject(fileMutations) as Dictionary<Mutation[]>),
+                },
+            };
+        };
+    });
+};

--- a/src/runtime/providers/createCoreMutationsProvider.ts
+++ b/src/runtime/providers/createCoreMutationsProvider.ts
@@ -32,7 +32,7 @@ export const createCoreMutationsProvider = (allModifiedFiles: Set<string>): Prov
         let lastFileIndex = -1;
         let waveIndex = 1;
 
-        return async () => {
+        return () => {
             const startTime = Date.now();
             const fileMutationsByFileName = new Map<string, ReadonlyArray<Mutation>>();
             const { fileNames, services } = fileNamesAndServicesCache.get();
@@ -66,7 +66,7 @@ export const createCoreMutationsProvider = (allModifiedFiles: Set<string>): Prov
                 }
 
                 const filteredNodes = collectFilteredNodes(options, sourceFile);
-                const foundMutations = await findMutationsInFile({
+                const foundMutations = findMutationsInFile({
                     fileInfoCache: new FileInfoCache(filteredNodes, services, sourceFile),
                     filteredNodes,
                     nameGenerator: new NameGenerator(sourceFile.fileName),

--- a/src/runtime/providers/createCoreMutationsProvider.ts
+++ b/src/runtime/providers/createCoreMutationsProvider.ts
@@ -66,14 +66,17 @@ export const createCoreMutationsProvider = (allModifiedFiles: Set<string>): Prov
                 }
 
                 const filteredNodes = collectFilteredNodes(options, sourceFile);
-                const foundMutations = findMutationsInFile({
-                    fileInfoCache: new FileInfoCache(filteredNodes, services, sourceFile),
-                    filteredNodes,
-                    nameGenerator: new NameGenerator(sourceFile.fileName),
-                    options,
-                    services,
-                    sourceFile,
-                });
+                const foundMutations = findMutationsInFile(
+                    {
+                        fileInfoCache: new FileInfoCache(filteredNodes, services, sourceFile),
+                        filteredNodes,
+                        nameGenerator: new NameGenerator(sourceFile.fileName),
+                        options,
+                        services,
+                        sourceFile,
+                    },
+                    options.mutators,
+                );
 
                 if (foundMutations !== undefined && foundMutations.length !== 0) {
                     addedMutations += foundMutations.length;

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -6,6 +6,6 @@ export interface ProvidedMutationsWave {
     newOptions?: TypeStatOptions;
 }
 
-export type Provider = () => Promise<ProvidedMutationsWave | undefined>;
+export type Provider = () => ProvidedMutationsWave | undefined | Promise<ProvidedMutationsWave | undefined>;
 
 export type ProviderCreator = (options: TypeStatOptions) => Provider | undefined;

--- a/src/shared/assignments.ts
+++ b/src/shared/assignments.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 import { getValueDeclarationOfFunction } from "./functionTypes";
 import { getTypeAtLocationIfNotError } from "./types";
 

--- a/src/shared/calls.ts
+++ b/src/shared/calls.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 import { getTypeAtLocationIfNotError } from "./types";
 
 export const getDeclaredTypesOfArgument = (

--- a/src/shared/comparisons.ts
+++ b/src/shared/comparisons.ts
@@ -1,7 +1,7 @@
 import { isUnionType } from "tsutils";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 import { ExposedTypeChecker } from "../mutations/createExposedTypeScript";
 import { isIntrisinicNameType, isOptionalTypeArgumentsTypeNode } from "./typeNodes";
 import { getTypeAtLocationIfNotError } from "./types";

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -1,0 +1,17 @@
+import * as ts from "typescript";
+
+export type DiagnosticWithStart = ts.Diagnostic & {
+    start: number;
+};
+
+export const isDiagnosticWithStart = (diagnostic: ts.Diagnostic): diagnostic is DiagnosticWithStart => {
+    return !!diagnostic.start;
+};
+
+export const getLineForDiagnostic = (diagnostic: DiagnosticWithStart, sourceFile: ts.SourceFile) => {
+    return ts.getLineAndCharacterOfPosition(sourceFile, diagnostic.start).line;
+};
+
+export const stringifyDiagnosticMessageText = (diagnostic: ts.Diagnostic) => {
+    return typeof diagnostic.messageText === "string" ? diagnostic.messageText : diagnostic.messageText.messageText;
+};

--- a/src/shared/fileMutator.ts
+++ b/src/shared/fileMutator.ts
@@ -3,10 +3,10 @@ import * as ts from "typescript";
 
 import { TypeStatOptions } from "../options/types";
 import { LanguageServices } from "../services/language";
-import { FileInfoCache } from "../shared/FileInfoCache";
-import { NameGenerator } from "../shared/NameGenerator";
+import { FileInfoCache } from "./FileInfoCache";
+import { NameGenerator } from "./NameGenerator";
 
-import { MutationsComplaint } from "./complaint";
+import { MutationsComplaint } from "../mutators/complaint";
 
 /**
  * Source file, metadata, and settings to collect mutations in the file.

--- a/src/shared/functionTypes.ts
+++ b/src/shared/functionTypes.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import * as tsutils from "tsutils";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 import { getValueDeclarationOfType } from "./nodeTypes";
 
 /**

--- a/src/shared/nodeExtensions.ts
+++ b/src/shared/nodeExtensions.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 import { getTypeAtLocationIfNotError } from "./types";
 
 export const getClassExtendsExpression = (node: ts.ClassLikeDeclaration): ts.ExpressionWithTypeArguments | undefined => {

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 import { isTypeFlagSetRecursively } from "../mutations/collecting/flags";
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 import { getTypeAtLocationIfNotError } from "./types";
 
 export type NodeSelector<TNode extends ts.Node> = (node: ts.Node) => node is TNode;

--- a/src/shared/nodes.ts
+++ b/src/shared/nodes.ts
@@ -1,7 +1,7 @@
 import * as tsutils from "tsutils";
 import * as ts from "typescript";
 
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 
 import { getValueDeclarationOfType, NodeSelector } from "./nodeTypes";
 

--- a/src/shared/printing/nodePrinting.ts
+++ b/src/shared/printing/nodePrinting.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 import { TypeSummariesByName, TypeSummary } from "../../mutations/expansions/summarization";
-import { FileMutationsRequest } from "../../mutators/fileMutator";
+import { FileMutationsRequest } from "../fileMutator";
 import { printNewLine } from "./newlines";
 
 export const printNamedTypeSummaries = (

--- a/src/shared/runtime.ts
+++ b/src/shared/runtime.ts
@@ -1,7 +1,7 @@
 import { Mutation } from "automutate";
 
 import { MutationsComplaint } from "../mutators/complaint";
-import { FileMutationsRequest, FileMutator } from "../mutators/fileMutator";
+import { FileMutationsRequest, FileMutator } from "./fileMutator";
 
 export const findFirstMutations = (
     request: FileMutationsRequest,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { FileMutationsRequest } from "../mutators/fileMutator";
+import { FileMutationsRequest } from "./fileMutator";
 import { isIntrisinicNameType } from "./typeNodes";
 
 /**

--- a/src/suppressions/builtin/suppressTypeErrors/index.ts
+++ b/src/suppressions/builtin/suppressTypeErrors/index.ts
@@ -10,13 +10,13 @@ import { TypeStatOptions } from "../../../options/types";
 import { LanguageServices } from "../../../services/language";
 import { Mutation } from "automutate";
 
-export interface SuppressionRequest {
+export interface CleanupRequest {
     readonly options: TypeStatOptions;
     readonly services: LanguageServices;
     readonly sourceFile: ts.SourceFile;
 }
 
-export const suppressRemainingTypeIssues = (request: SuppressionRequest): ReadonlyArray<Mutation> | undefined => {
+export const suppressRemainingTypeIssues = (request: CleanupRequest): ReadonlyArray<Mutation> | undefined => {
     if (!request.options.cleanups.suppressTypeErrors) {
         return undefined;
     }

--- a/src/suppressions/builtin/suppressTypeErrors/index.ts
+++ b/src/suppressions/builtin/suppressTypeErrors/index.ts
@@ -1,0 +1,52 @@
+import * as ts from "typescript";
+
+import {
+    DiagnosticWithStart,
+    getLineForDiagnostic,
+    isDiagnosticWithStart,
+    stringifyDiagnosticMessageText,
+} from "../../../shared/diagnostics";
+import { TypeStatOptions } from "../../../options/types";
+import { LanguageServices } from "../../../services/language";
+import { Mutation } from "automutate";
+
+export interface SuppressionRequest {
+    readonly options: TypeStatOptions;
+    readonly services: LanguageServices;
+    readonly sourceFile: ts.SourceFile;
+}
+
+export const suppressRemainingTypeIssues = (request: SuppressionRequest): ReadonlyArray<Mutation> | undefined => {
+    if (!request.options.cleanups.suppressTypeErrors) {
+        return undefined;
+    }
+
+    const allDiagnostics = request.services.program.getSemanticDiagnostics(request.sourceFile).filter(isDiagnosticWithStart);
+    if (!allDiagnostics.length) {
+        return undefined;
+    }
+
+    const diagnosticsPerLine = new Map<number, DiagnosticWithStart[]>();
+
+    for (const diagnostic of allDiagnostics) {
+        const line = getLineForDiagnostic(diagnostic, request.sourceFile);
+        const existing = diagnosticsPerLine.get(line);
+
+        if (existing) {
+            existing.push(diagnostic);
+        } else {
+            diagnosticsPerLine.set(line, [diagnostic]);
+        }
+    }
+
+    return Array.from(diagnosticsPerLine).map(([line, diagnostics]) => {
+        const messages = diagnostics.map(stringifyDiagnosticMessageText).join(" ");
+        return {
+            insertion: `// @ts-expect-error -- TODO: ${messages}\n`,
+            range: {
+                begin: ts.getPositionOfLineAndCharacter(request.sourceFile, line, 0),
+            },
+            type: "text-insert",
+        };
+    });
+};

--- a/src/suppressors/builtin/suppressTypeErrors/index.ts
+++ b/src/suppressors/builtin/suppressTypeErrors/index.ts
@@ -10,13 +10,13 @@ import { TypeStatOptions } from "../../../options/types";
 import { LanguageServices } from "../../../services/language";
 import { Mutation } from "automutate";
 
-export interface SuppressionRequest {
+export interface CleanupRequest {
     readonly options: TypeStatOptions;
     readonly services: LanguageServices;
     readonly sourceFile: ts.SourceFile;
 }
 
-export const suppressRemainingTypeIssues = (request: SuppressionRequest): ReadonlyArray<Mutation> | undefined => {
+export const suppressRemainingTypeIssues = (request: CleanupRequest): ReadonlyArray<Mutation> | undefined => {
     if (!request.options.cleanups.suppressTypeErrors) {
         return undefined;
     }

--- a/src/suppressors/builtin/suppressTypeErrors/index.ts
+++ b/src/suppressors/builtin/suppressTypeErrors/index.ts
@@ -1,0 +1,52 @@
+import * as ts from "typescript";
+
+import {
+    DiagnosticWithStart,
+    getLineForDiagnostic,
+    isDiagnosticWithStart,
+    stringifyDiagnosticMessageText,
+} from "../../../shared/diagnostics";
+import { TypeStatOptions } from "../../../options/types";
+import { LanguageServices } from "../../../services/language";
+import { Mutation } from "automutate";
+
+export interface SuppressionRequest {
+    readonly options: TypeStatOptions;
+    readonly services: LanguageServices;
+    readonly sourceFile: ts.SourceFile;
+}
+
+export const suppressRemainingTypeIssues = (request: SuppressionRequest): ReadonlyArray<Mutation> | undefined => {
+    if (!request.options.cleanups.suppressTypeErrors) {
+        return undefined;
+    }
+
+    const allDiagnostics = request.services.program.getSemanticDiagnostics(request.sourceFile).filter(isDiagnosticWithStart);
+    if (!allDiagnostics.length) {
+        return undefined;
+    }
+
+    const diagnosticsPerLine = new Map<number, DiagnosticWithStart[]>();
+
+    for (const diagnostic of allDiagnostics) {
+        const line = getLineForDiagnostic(diagnostic, request.sourceFile);
+        const existing = diagnosticsPerLine.get(line);
+
+        if (existing) {
+            existing.push(diagnostic);
+        } else {
+            diagnosticsPerLine.set(line, [diagnostic]);
+        }
+    }
+
+    return Array.from(diagnosticsPerLine).map(([line, diagnostics]) => {
+        const messages = diagnostics.map(stringifyDiagnosticMessageText).join(" ");
+        return {
+            insertion: `// @ts-expect-error -- TODO: ${messages}\n`,
+            range: {
+                begin: ts.getPositionOfLineAndCharacter(request.sourceFile, line, 0),
+            },
+            type: "text-insert",
+        };
+    });
+};

--- a/test/cases/cleanups/suppressTypeErrors/expected.ts
+++ b/test/cases/cleanups/suppressTypeErrors/expected.ts
@@ -1,0 +1,7 @@
+(function () {
+// @ts-expect-error -- TODO: Type 'number' is not assignable to type 'string'.
+    let incorrectSingle: string = 0;
+
+// @ts-expect-error -- TODO: Property 'replace' does not exist on type 'undefined[]'. Property 'values' does not exist on type '{}'.
+    let incorrectMutiple: string = [].replace() + {}.values();
+})();

--- a/test/cases/cleanups/suppressTypeErrors/original.ts
+++ b/test/cases/cleanups/suppressTypeErrors/original.ts
@@ -1,0 +1,5 @@
+(function () {
+    let incorrectSingle: string = 0;
+
+    let incorrectMutiple: string = [].replace() + {}.values();
+})();

--- a/test/cases/cleanups/suppressTypeErrors/tsconfig.json
+++ b/test/cases/cleanups/suppressTypeErrors/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    },
+    "files": ["actual.ts"]
+}

--- a/test/cases/cleanups/suppressTypeErrors/typestat.json
+++ b/test/cases/cleanups/suppressTypeErrors/typestat.json
@@ -1,0 +1,5 @@
+{
+    "cleanups": {
+        "suppressTypeErrors": true
+    }
+}


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1224
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds a _"cleanups"_ section for explicitly running _after_ fixers. For now, only one "cleaner" exists: `suppressTypeError`, for adding `// @ts-expect-error` comments on any remaining type errors. I'll file a followup issue for adding `: any` the way `ts-migrate` does.

I wasn't planning on tackling this issue, but ended up having a few spare hours on a flight...