### PR TITLE
fix: don't expand existing type with explicit any

### DIFF
--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -23,7 +23,7 @@ export const createTypeAdditionMutation = (
     declaredType: ts.Type,
     allAssignedTypes: ReadonlyArray<ts.Type>,
 ): TextInsertMutation | TextSwapMutation | undefined => {
-    // Declared types inherently can't be incomplete
+    // Declared 'any' types inherently can't be incomplete
     if (tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)) {
         return undefined;
     }

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -23,6 +23,11 @@ export const createTypeAdditionMutation = (
     declaredType: ts.Type,
     allAssignedTypes: ReadonlyArray<ts.Type>,
 ): TextInsertMutation | TextSwapMutation | undefined => {
+    // Declared types inherently can't be incomplete
+    if (tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)) {
+        return undefined;
+    }
+
     // Find any missing flags and symbols (a.k.a. types)
     const { missingFlags, missingTypes } = collectUsageFlagsAndSymbols(request, declaredType, allAssignedTypes);
 

--- a/test/cases/fixes/incompleteTypes/parameterTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/parameterTypes/expected.ts
@@ -9,4 +9,8 @@
     function passesStringOrBoolean(input: string | boolean) {
         takesStringOrBoolean(input);
     }
+
+    function takesAny(
+        input: any = {}
+    ) {}
 })()

--- a/test/cases/fixes/incompleteTypes/parameterTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/parameterTypes/original.ts
@@ -9,4 +9,8 @@
     function passesStringOrBoolean(input: string | boolean) {
         takesStringOrBoolean(input);
     }
+
+    function takesAny(
+        input: any = {}
+    ) {}
 })()


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1278
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds logic to `createTypeAdditionMutation` to return no mutation if the declared type includes `any`.