### PR TITLE
feat: log full error stacks on crash

### DIFF
--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -41,18 +41,35 @@ describe("runCli", () => {
         expect(resultStatus).toEqual(ResultStatus.Succeeded);
     });
 
-    it("logs an error when the main runner rejects with one", async () => {
+    it("logs a string when the main runner rejects with one", async () => {
         // Arrange
         const { argv, initializationRunner, output, mainRunner } = createTestArgs("--config", "typestat.json");
         const message = "Error message";
 
-        mainRunner.mockRejectedValue(new Error(message));
+        mainRunner.mockRejectedValue(message);
 
         // Act
         const resultStatus = await runCli(argv, { initializationRunner, output, mainRunner });
 
         // Assert
-        expect(output.stderr).toHaveBeenLastCalledWith(expect.stringMatching(message));
+        expect(output.stderr).toHaveBeenCalledWith(expect.stringMatching(message));
+        expect(resultStatus).toEqual(ResultStatus.Failed);
+    });
+
+    it("logs an error with a stack when the main runner rejects with one", async () => {
+        // Arrange
+        const { argv, initializationRunner, output, mainRunner } = createTestArgs("--config", "typestat.json");
+        const message = "Error message";
+        const error = new Error(message);
+
+        mainRunner.mockRejectedValue(error);
+
+        // Act
+        const resultStatus = await runCli(argv, { initializationRunner, output, mainRunner });
+
+        // Assert
+        expect(output.stderr).toHaveBeenCalledWith(expect.stringMatching(message));
+        expect(output.stderr).toHaveBeenLastCalledWith(expect.stringMatching("  at"));
         expect(resultStatus).toEqual(ResultStatus.Failed);
     });
 

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -68,11 +68,11 @@ export const runCli = async (rawArgv: readonly string[], runtime?: CliRuntime): 
     switch (result.status) {
         case ResultStatus.ConfigurationError:
             runtime.output.stdout(command.helpInformation());
-            runtime.output.stderr(chalk.yellow(result.error));
+            logError(runtime, result.error);
             break;
 
         case ResultStatus.Failed:
-            runtime.output.stderr(chalk.yellow(result.error));
+            logError(runtime, result.error);
             break;
 
         case ResultStatus.Succeeded:
@@ -88,4 +88,12 @@ const getPackageVersion = async (): Promise<string> => {
     const rawText = (await fs.readFile(packagePath)).toString();
 
     return (JSON.parse(rawText) as { version: string }).version;
+};
+
+const logError = (runtime: CliRuntime, error: Error | string) => {
+    runtime.output.stderr(chalk.yellow(error));
+
+    if (error instanceof Error && error.stack) {
+        runtime.output.stderr(chalk.gray(error.stack.slice(error.stack.indexOf("\n") + 1)));
+    }
 };


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1311
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/labels/status%3A%20accepting%20prs)

## Overview

Adds an extra bit of logging if the rejected error is an `Error`.