### PR TITLE
chore: set eslint to ignore lib folder

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -51,8 +51,6 @@ ESLint can be run with `--fix` to auto-fix some lint rule complaints:
 pnpm run lint --fix
 ```
 
-Note that you'll likely need to run `pnpm build` before `pnpm lint` so that lint rules which check the file system can pick up on any built files.
-
 ## Testing
 
 There are two kinds of tests:

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,1 +1,1 @@
-{ "extends": "./tsconfig.json", "include": ["."] }
+{ "exclude": ["lib"], "extends": "./tsconfig.json", "include": ["."] }


### PR DESCRIPTION
…eporting

<!-- 👋 Hi, thanks for sending a PR to TypeStat! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1478
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Eslint has different result depending on if `lib`folder is present or not. When it is present, lint errors seems incorrect.

Excluding "lib" from eslint fixes the issue. Also, removed mention that you should build the project before linting. This is not done in CI and it seems unnecessary in current state. :) 