### PR TITLE
fix: No more adding infinite boolean for function returning promise

### DIFF
--- a/src/mutations/collecting/flags.ts
+++ b/src/mutations/collecting/flags.ts
@@ -6,6 +6,8 @@ import { setSubtract } from "../../shared/sets.js";
 const knownTypeFlagEquivalents = new Map([
 	[ts.TypeFlags.BigInt, ts.TypeFlags.BigIntLiteral],
 	[ts.TypeFlags.BigIntLiteral, ts.TypeFlags.BigInt],
+	[ts.TypeFlags.Boolean, ts.TypeFlags.BooleanLiteral],
+	[ts.TypeFlags.BooleanLiteral, ts.TypeFlags.Boolean],
 	[ts.TypeFlags.Number, ts.TypeFlags.NumberLiteral],
 	[ts.TypeFlags.NumberLiteral, ts.TypeFlags.Number],
 	[ts.TypeFlags.String, ts.TypeFlags.StringLiteral],

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -84,4 +84,27 @@
 
 		return "";
 	};
+
+	async function navigateTo(): Promise<boolean> {
+		return await new Promise(() => "");
+	}
+
+	function navigateByUrl(url: string): Promise<boolean>;
+
+	async function navigateTo(): Promise<boolean> | boolean {
+		return await navigateByUrl("");
+	}
+
+	async function navigateTo2(): Promise<boolean> | boolean {
+		const navigated = await navigateByUrl("");
+		return navigated;
+	}
+
+	async function returnSame(): Promise<boolean> {
+		return navigateByUrl("");
+	}
+
+	async function returnPromise(): Promise<string> {
+		return Promise.resolve("");
+	}
 })();

--- a/test/cases/fixes/incompleteTypes/returnTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/original.ts
@@ -84,4 +84,27 @@
 
 		return "";
 	};
+
+	async function navigateTo(): Promise<boolean> {
+		return await new Promise(() => "");
+	}
+
+	function navigateByUrl(url: string): Promise<boolean>;
+
+	async function navigateTo(): Promise<boolean> {
+		return await navigateByUrl("");
+	}
+
+	async function navigateTo2(): Promise<boolean> {
+		const navigated = await navigateByUrl("");
+		return navigated;
+	}
+
+	async function returnSame(): Promise<boolean> {
+		return navigateByUrl("");
+	}
+
+	async function returnPromise(): Promise<string> {
+		return Promise.resolve("");
+	}
 })();


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to TypeStat! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1447 - I think it also fixes #1284
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken 😹 

## Overview

<!-- Description of what is changed and how the code change does that. -->

It was this small change in the end??

Note, `async function navigateTo(): Promise<boolean> | boolean {` and `async function navigateTo2(): Promise<boolean> | boolean {` are wrong. Both should return only `Promise<boolean>`. I can remove those from the test but I wanted to keep them to see, the difference.