### PR TITLE
fix: NoInfereableTypes should not remove types from all consts

### DIFF
--- a/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesVariableDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesVariableDeclarations/index.ts
@@ -1,5 +1,4 @@
 import { Mutation } from "automutate";
-import * as tsutils from "ts-api-utils";
 import ts from "typescript";
 
 import { createTypeRemovalMutation } from "../../../../mutations/removals.js";
@@ -39,9 +38,6 @@ const getNoInferableTypeVariableDeclarationMutation = (
 	request: FileMutationsRequest,
 ) => {
 	if (
-		// `const` variables should always have their declarations removed
-		tsutils.isNodeFlagSet(node.parent, ts.NodeFlags.Const) ||
-		// `let` variables should have only uninformative declarations removed
 		declaredInitializedTypeNodeIsRedundant(request, node.type, node.initializer)
 	) {
 		return createTypeRemovalMutation(request, node);

--- a/test/cases/fixes/noInferableTypes/variableDeclarations/expected.ts
+++ b/test/cases/fixes/noInferableTypes/variableDeclarations/expected.ts
@@ -47,8 +47,8 @@
 	let letInferableNumberOrRegExps = [0, /./];
 
 	// Non-inferable const multi-type arrays
-	const constNonInferableNullOrStrings = [null];
-	const constNonInferableNumberOrRegExps = [0];
+	const constNonInferableNullOrStrings: (null | string)[] = [null];
+	const constNonInferableNumberOrRegExps: (number | RegExp)[] = [0];
 
 	// Non-inferable let multi-type arrays
 	let letNonInferableNullOrStrings: (null | string)[] = [null];
@@ -65,17 +65,17 @@
 	let letTakesChild = new Child();
 
 	// Non-inferable const direct class instances
-	const constTakesParentAsChild = new Child();
+	const constTakesParentAsChild: Parent = new Child();
 
 	// Non-inferable let direct class instances
 	let letTakesParentAsChild: Parent = new Child();
 
 	// Non-inferable const union class instances
-	const constTakesParentOrChildAsParent = new Parent();
-	const constTakesParentOrChildAsChild = new Child();
-	const constTakesParentOrUndefinedAsParent = new Parent();
-	const constTakesParentOrUndefinedAsChild = new Child();
-	const constTakesChildOrUndefinedAsChild = new Child();
+	const constTakesParentOrChildAsParent: Parent | Child = new Parent();
+	const constTakesParentOrChildAsChild: Parent | Child = new Child();
+	const constTakesParentOrUndefinedAsParent: Parent | undefined = new Parent();
+	const constTakesParentOrUndefinedAsChild: Parent | undefined = new Child();
+	const constTakesChildOrUndefinedAsChild: Child | undefined = new Child();
 
 	// Non-inferable let union class instances
 	let letTakesParentOrChildAsParent: Parent | Child = new Parent();
@@ -83,4 +83,23 @@
 	let letTakesParentOrUndefinedAsParent: Parent | undefined = new Parent();
 	let letTakesParentOrUndefinedAsChild: Parent | undefined = new Child();
 	let letTakesChildOrUndefinedAsChild: Child | undefined = new Child();
+
+	// should keep their types
+	// map
+	type TypeSummariesPerNodeByName = Map<string, unknown>;
+	const incompleteTypes: TypeSummariesPerNodeByName = new Map();
+	// array
+	interface Mutation {
+		readonly range: number;
+		readonly type: string;
+	}
+	const mutations: Mutation[] = [];
+	// function
+	type FileMutationsRequest = Record<string, unknown>;
+	type FileMutator = (
+		request: FileMutationsRequest,
+	) => readonly Mutation[] | undefined;
+	const fixIncompleteImplicitClassGenerics: FileMutator = (
+		request: FileMutationsRequest,
+	) => undefined;
 })();

--- a/test/cases/fixes/noInferableTypes/variableDeclarations/original.ts
+++ b/test/cases/fixes/noInferableTypes/variableDeclarations/original.ts
@@ -83,4 +83,23 @@
 	let letTakesParentOrUndefinedAsParent: Parent | undefined = new Parent();
 	let letTakesParentOrUndefinedAsChild: Parent | undefined = new Child();
 	let letTakesChildOrUndefinedAsChild: Child | undefined = new Child();
+
+	// should keep their types
+	// map
+	type TypeSummariesPerNodeByName = Map<string, unknown>;
+	const incompleteTypes: TypeSummariesPerNodeByName = new Map();
+	// array
+	interface Mutation {
+		readonly range: number;
+		readonly type: string;
+	}
+	const mutations: Mutation[] = [];
+	// function
+	type FileMutationsRequest = Record<string, unknown>;
+	type FileMutator = (
+		request: FileMutationsRequest,
+	) => readonly Mutation[] | undefined;
+	const fixIncompleteImplicitClassGenerics: FileMutator = (
+		request: FileMutationsRequest,
+	) => undefined;
 })();


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to TypeStat! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1498
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken 🐙 

## Overview

<!-- Description of what is changed and how the code change does that. -->

It's not safe to remove type from const always. I think the mutation tests agree with me. Some things are marked as "non-inferable" but still their types were removed. 