### PR TITLE
chore(tests): snapshot mutation options

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -16,8 +16,8 @@
 		"endlines",
 		"execa",
 		"extensionless",
-		"hackily",
 		"globbed",
+		"hackily",
 		"IIFE",
 		"inferables",
 		"intrinsic",
@@ -33,6 +33,7 @@
 		"tsup",
 		"typestat",
 		"undefineds",
-		"uniquify"
+		"uniquify",
+		"vitest"
 	]
 }

--- a/src/tests/testSetup.ts
+++ b/src/tests/testSetup.ts
@@ -1,18 +1,21 @@
 import { runMutations } from "automutate";
 import fs from "node:fs/promises";
 import path from "node:path";
-import ts from "typescript";
 
 import { fillOutRawOptions } from "../options/fillOutRawOptions.js";
+import { parseRawCompilerOptions } from "../options/parseRawCompilerOptions.js";
 import { RawTypeStatOptions } from "../options/types.js";
 import { createTypeStatProvider } from "../runtime/createTypeStatProvider.js";
 
 export interface MutationTestResult {
 	actualContent: string;
 	expectedFilePath: string;
+	options: string;
 }
 
-export const runMutationTest = async (dirPath: string) => {
+export const runMutationTest = async (
+	dirPath: string,
+): Promise<MutationTestResult> => {
 	const originalFileName = (await fs.readdir(dirPath)).find((file) =>
 		file.startsWith("original."),
 	);
@@ -21,26 +24,21 @@ export const runMutationTest = async (dirPath: string) => {
 	}
 
 	const readFile = (filename: string) =>
-		fs.readFile(path.join(dirPath, filename), {
-			encoding: "utf-8",
-		});
+		fs.readFile(path.join(dirPath, filename), "utf-8");
+
+	const originalFile = path.join(dirPath, originalFileName);
+	const fileNameSuffix = originalFileName.endsWith("x") ? "x" : "";
+	const actualFileName = `actual.ts${fileNameSuffix}`;
+	const actualFile = path.join(dirPath, actualFileName);
+	// file needs to exists before creating compiler options
+	await fs.copyFile(originalFile, actualFile);
 
 	const rawTypeStatOptions = await readFile("typestat.json");
 	const rawOptions = JSON.parse(rawTypeStatOptions) as RawTypeStatOptions;
 
 	const projectPath = path.join(dirPath, "tsconfig.json");
-	const rawCompilerOptionsJson = await readFile("tsconfig.json");
-	const convertResult = ts.parseConfigFileTextToJson(
-		"tsconfig.json",
-		rawCompilerOptionsJson,
-	);
 
-	if (convertResult.error) {
-		console.error(convertResult.error);
-		throw new Error("Error while reading tsconfig");
-	}
-
-	const compilerOptions = convertResult.config as ts.CompilerOptions;
+	const compilerOptions = await parseRawCompilerOptions(dirPath, projectPath);
 
 	const output = {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -50,22 +48,17 @@ export const runMutationTest = async (dirPath: string) => {
 		stdout: () => {},
 	};
 
-	const fileNameSuffix = originalFileName.endsWith("x") ? "x" : "";
-	const originalFile = path.join(dirPath, originalFileName);
-	const actualFileName = `actual.ts${fileNameSuffix}`;
-	const actualFile = path.join(dirPath, actualFileName);
-
-	await fs.copyFile(originalFile, actualFile);
+	const pendingOptions = fillOutRawOptions({
+		argv: { args: [] },
+		compilerOptions,
+		cwd: dirPath,
+		output,
+		projectPath,
+		rawOptions,
+	});
 
 	const provider = createTypeStatProvider({
-		...fillOutRawOptions({
-			argv: { args: [] },
-			compilerOptions,
-			cwd: dirPath,
-			output,
-			projectPath,
-			rawOptions,
-		}),
+		...pendingOptions,
 		fileNames: [actualFile],
 	});
 
@@ -77,5 +70,10 @@ export const runMutationTest = async (dirPath: string) => {
 	const expectFileName = `expected.ts${fileNameSuffix}`;
 	const expectedFilePath = path.join(dirPath, expectFileName);
 
-	return { actualContent, expectedFilePath };
+	const optionsSnapshot = JSON.stringify(pendingOptions, null, 2).replaceAll(
+		dirPath,
+		"<rootDir>",
+	);
+
+	return { actualContent, expectedFilePath, options: optionsSnapshot };
 };

--- a/test/__snapshots__/cleanups.test.ts.snap
+++ b/test/__snapshots__/cleanups.test.ts.snap
@@ -1,0 +1,81 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Cleanups > suppressTypeErrors > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": true
+  },
+  "compilerOptions": {
+    "compilerOptions": {
+      "strictNullChecks": true
+    },
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;

--- a/test/__snapshots__/customMutators.test.ts.snap
+++ b/test/__snapshots__/customMutators.test.ts.snap
@@ -1,0 +1,192 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Custom mutators > empty array > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Custom mutators > one mutator > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "include": [
+      "actual.ts"
+    ],
+    "compileOnSave": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "include": [
+    "actual.ts"
+  ],
+  "mutators": [
+    [
+      "./sampleMutator.cjs",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Custom mutators > two mutators > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "./mutator1.cjs",
+      null
+    ],
+    [
+      "./mutator2.cjs",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;

--- a/test/__snapshots__/files.test.ts.snap
+++ b/test/__snapshots__/files.test.ts.snap
@@ -1,0 +1,309 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`files > addition above > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "/* Above file */",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`files > addition below > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "/* Below file */",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`files > both > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "/* Above file */",
+    "below": "/* Below file */",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`files > empty addition > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;

--- a/test/__snapshots__/filters.test.ts.snap
+++ b/test/__snapshots__/filters.test.ts.snap
@@ -1,0 +1,243 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`filters > empty > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`filters > one > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [
+    "FunctionDeclaration[name.text=one]"
+  ],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`filters > two > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [
+    "MethodDeclaration[name.text=dispose]",
+    "CallExpression[expression.text=teardown]"
+  ],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;

--- a/test/__snapshots__/fixImportExtensions.test.ts.snap
+++ b/test/__snapshots__/fixImportExtensions.test.ts.snap
@@ -1,0 +1,80 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`import extensions > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts",
+      "foundDirect.ts",
+      "foundIndirect/index.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": true,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;

--- a/test/__snapshots__/fixIncompleteTypes.test.ts.snap
+++ b/test/__snapshots__/fixIncompleteTypes.test.ts.snap
@@ -1,0 +1,1335 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Incomplete types > Implicit generics > incomplete implicit class generics > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts",
+      "react-like.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > Implicit generics > incomplete implicit variable generics > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > Interface or type literal generics > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > Non-generic Interface as Type argument > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > React props from prop types > Optionality > always optional > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "alwaysOptional"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > React props from prop types > Optionality > always required > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "alwaysRequired"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > React props from prop types > Optionality > as written > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > React props from prop types > all > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > not react props > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "compilerOptions": {
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": "react"
+    },
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > react prop functions from calls > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "compilerOptions": {
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": "react"
+    },
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > react props from later assignments > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > react props from prop uses > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "compilerOptions": {
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": "react"
+    },
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > React types > react props missing > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "compilerOptions": {
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": "react"
+    },
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > parameter types > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > property declaration types > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`Incomplete types > return types > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`Incomplete types > variable types > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.tsx"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;

--- a/test/__snapshots__/fixMissingProperties.test.ts.snap
+++ b/test/__snapshots__/fixMissingProperties.test.ts.snap
@@ -1,0 +1,80 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Missing properties > missing property accesses > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;

--- a/test/__snapshots__/fixNoImplicitAny.test.ts.snap
+++ b/test/__snapshots__/fixNoImplicitAny.test.ts.snap
@@ -1,0 +1,238 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`noImplicitAny > parameters > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`noImplicitAny > property declarations > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`noImplicitAny > variable declarations > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;

--- a/test/__snapshots__/fixNoImplicitThis.test.ts.snap
+++ b/test/__snapshots__/fixNoImplicitThis.test.ts.snap
@@ -1,0 +1,80 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`noImplicitThis > noImplicitThis > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;

--- a/test/__snapshots__/fixNoInferableTypes.test.ts.snap
+++ b/test/__snapshots__/fixNoInferableTypes.test.ts.snap
@@ -1,0 +1,238 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`No inferable types > parameters > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": true,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`No inferable types > property declarations > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": true,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`No inferable types > variable declarations > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": true,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;

--- a/test/__snapshots__/fixStrictNonNullAssertions.test.ts.snap
+++ b/test/__snapshots__/fixStrictNonNullAssertions.test.ts.snap
@@ -1,0 +1,402 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`strictNonNullAssertions > binaryExpressions > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "compilerOptions": {
+      "strictNullChecks": true
+    },
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": true
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`strictNonNullAssertions > callExpressions > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": true
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`strictNonNullAssertions > objectLiterals > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": true
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`strictNonNullAssertions > propertyAccesses > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": true
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;
+
+exports[`strictNonNullAssertions > returnTypes > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "compilerOptions": {
+      "strictNullChecks": true
+    },
+    "files": [
+      "actual.ts"
+    ],
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": true
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": true
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {
+    "strictNullChecks": true
+  }
+}"
+`;

--- a/test/__snapshots__/include.test.ts.snap
+++ b/test/__snapshots__/include.test.ts.snap
@@ -1,0 +1,115 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`include > asterisk > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "include": [
+      "original.ts",
+      "expected.ts",
+      "actual.ts"
+    ],
+    "compileOnSave": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "include": [
+    "original.ts",
+    "expected.ts",
+    "actual.ts"
+  ],
+  "mutators": [
+    [
+      "./sampleMutator.cjs",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;
+
+exports[`include > directory > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "include": [],
+    "compileOnSave": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "include": [],
+  "mutators": [
+    [
+      "./sampleMutator.cjs",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;

--- a/test/__snapshots__/infiniteWaveDetection.test.ts.snap
+++ b/test/__snapshots__/infiniteWaveDetection.test.ts.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Infinite wave detection > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "include": [
+      "actual.ts"
+    ],
+    "compileOnSave": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": false,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "include": [
+    "actual.ts"
+  ],
+  "mutators": [
+    [
+      "./infiniteMutator.cjs",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": []
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;

--- a/test/__snapshots__/postProcessing.test.ts.snap
+++ b/test/__snapshots__/postProcessing.test.ts.snap
@@ -1,0 +1,87 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Post processing > options 1`] = `
+"{
+  "cleanups": {
+    "suppressTypeErrors": false
+  },
+  "compilerOptions": {
+    "include": [
+      "actual.ts"
+    ],
+    "compileOnSave": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
+  },
+  "files": {
+    "above": "",
+    "below": "",
+    "renameExtensions": false
+  },
+  "filters": [],
+  "fixes": {
+    "importExtensions": false,
+    "incompleteTypes": true,
+    "missingProperties": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noInferableTypes": false,
+    "strictNonNullAssertions": false
+  },
+  "hints": {
+    "react": {
+      "propTypes": "whenRequired",
+      "propTypesOptionality": "asWritten"
+    }
+  },
+  "include": [
+    "actual.ts"
+  ],
+  "mutators": [
+    [
+      "fixImportExtensions",
+      null
+    ],
+    [
+      "fixIncompleteTypes",
+      null
+    ],
+    [
+      "fixMissingProperties",
+      null
+    ],
+    [
+      "fixNoImplicitAny",
+      null
+    ],
+    [
+      "fixNoImplicitThis",
+      null
+    ],
+    [
+      "fixNoInferableTypes",
+      null
+    ],
+    [
+      "fixStrictNonNullAssertions",
+      null
+    ]
+  ],
+  "output": {},
+  "package": {
+    "directory": "<rootDir>",
+    "file": "<rootDir>/package.json"
+  },
+  "postProcess": {
+    "shell": [
+      [
+        "node",
+        "./postProcess.cjs"
+      ]
+    ]
+  },
+  "projectPath": "<rootDir>/tsconfig.json",
+  "types": {}
+}"
+`;

--- a/test/cleanups.test.ts
+++ b/test/cleanups.test.ts
@@ -9,7 +9,9 @@ describe("Cleanups", () => {
 			import.meta.dirname,
 			"cases/cleanups/suppressTypeErrors",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/customMutators.test.ts
+++ b/test/customMutators.test.ts
@@ -9,19 +9,25 @@ describe("Custom mutators", () => {
 			import.meta.dirname,
 			"cases/custom mutators/empty",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("one mutator", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/custom mutators/one");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("two mutators", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/custom mutators/two");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -6,25 +6,33 @@ import { runMutationTest } from "../src/tests/testSetup.js";
 describe("files", () => {
 	it("addition above", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/files/above");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	}, 50000);
 
 	it("addition below", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/files/below");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	}, 50000);
 
 	it("both", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/files/both");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("empty addition", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/files/empty");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/filters.test.ts
+++ b/test/filters.test.ts
@@ -6,19 +6,25 @@ import { runMutationTest } from "../src/tests/testSetup.js";
 describe("filters", () => {
 	it("empty", async () => {
 		const caseDir = path.join(import.meta.dirname, "./cases/filters/empty");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
-	});
+		expect(options).toMatchSnapshot("options");
+	}, 7000);
 
 	it("one", async () => {
 		const caseDir = path.join(import.meta.dirname, "./cases/filters/one");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("two", async () => {
 		const caseDir = path.join(import.meta.dirname, "./cases/filters/two");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/fixImportExtensions.test.ts
+++ b/test/fixImportExtensions.test.ts
@@ -8,6 +8,8 @@ test("import extensions", async () => {
 		import.meta.dirname,
 		"cases/fixes/importExtensions",
 	);
-	const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+	const { actualContent, expectedFilePath, options } =
+		await runMutationTest(caseDir);
 	await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+	expect(options).toMatchSnapshot("options");
 }, 10000);

--- a/test/fixIncompleteTypes.test.ts
+++ b/test/fixIncompleteTypes.test.ts
@@ -12,9 +12,10 @@ describe("Incomplete types", () => {
 				dirname,
 				"cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitClassGenerics",
 			);
-			const { actualContent, expectedFilePath } =
+			const { actualContent, expectedFilePath, options } =
 				await runMutationTest(caseDir);
 			await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+			expect(options).toMatchSnapshot("options");
 		}, 50000);
 
 		it("incomplete implicit variable generics", async () => {
@@ -22,9 +23,10 @@ describe("Incomplete types", () => {
 				dirname,
 				"cases/fixes/incompleteTypes/implicitGenerics/incompleteImplicitVariableGenerics",
 			);
-			const { actualContent, expectedFilePath } =
+			const { actualContent, expectedFilePath, options } =
 				await runMutationTest(caseDir);
 			await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+			expect(options).toMatchSnapshot("options");
 		}, 50000);
 	});
 
@@ -33,8 +35,10 @@ describe("Incomplete types", () => {
 			dirname,
 			"cases/fixes/incompleteTypes/interfaceOrTypeLiteralGenerics",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	}, 50000);
 
 	it("Non-generic Interface as Type argument", async () => {
@@ -42,8 +46,10 @@ describe("Incomplete types", () => {
 			dirname,
 			"cases/fixes/incompleteTypes/nonGenericInterfaceAsTypeArgument",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	}, 50000);
 
 	it("parameter types", async () => {
@@ -51,8 +57,10 @@ describe("Incomplete types", () => {
 			dirname,
 			"cases/fixes/incompleteTypes/parameterTypes",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("property declaration types", async () => {
@@ -60,8 +68,10 @@ describe("Incomplete types", () => {
 			dirname,
 			"cases/fixes/incompleteTypes/propertyDeclarationTypes",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	}, 50000);
 
 	describe("React types", () => {
@@ -70,9 +80,10 @@ describe("Incomplete types", () => {
 				dirname,
 				"cases/fixes/incompleteTypes/reactTypes/notReactProps",
 			);
-			const { actualContent, expectedFilePath } =
+			const { actualContent, expectedFilePath, options } =
 				await runMutationTest(caseDir);
 			await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+			expect(options).toMatchSnapshot("options");
 		});
 
 		it("react prop functions from calls", async () => {
@@ -80,9 +91,10 @@ describe("Incomplete types", () => {
 				dirname,
 				"cases/fixes/incompleteTypes/reactTypes/reactPropFunctionsFromCalls",
 			);
-			const { actualContent, expectedFilePath } =
+			const { actualContent, expectedFilePath, options } =
 				await runMutationTest(caseDir);
 			await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+			expect(options).toMatchSnapshot("options");
 		}, 50000);
 
 		it("react props from later assignments", async () => {
@@ -90,9 +102,10 @@ describe("Incomplete types", () => {
 				dirname,
 				"cases/fixes/incompleteTypes/reactTypes/reactPropsFromLaterAssignments",
 			);
-			const { actualContent, expectedFilePath } =
+			const { actualContent, expectedFilePath, options } =
 				await runMutationTest(caseDir);
 			await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+			expect(options).toMatchSnapshot("options");
 		}, 50000);
 
 		describe("React props from prop types", () => {
@@ -101,9 +114,10 @@ describe("Incomplete types", () => {
 					dirname,
 					"cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/all",
 				);
-				const { actualContent, expectedFilePath } =
+				const { actualContent, expectedFilePath, options } =
 					await runMutationTest(caseDir);
 				await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+				expect(options).toMatchSnapshot("options");
 			}, 50000);
 
 			describe("Optionality", () => {
@@ -112,9 +126,10 @@ describe("Incomplete types", () => {
 						dirname,
 						"cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/alwaysOptional",
 					);
-					const { actualContent, expectedFilePath } =
+					const { actualContent, expectedFilePath, options } =
 						await runMutationTest(caseDir);
 					await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+					expect(options).toMatchSnapshot("options");
 				});
 
 				it("always required", async () => {
@@ -122,9 +137,10 @@ describe("Incomplete types", () => {
 						dirname,
 						"cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/alwaysRequired",
 					);
-					const { actualContent, expectedFilePath } =
+					const { actualContent, expectedFilePath, options } =
 						await runMutationTest(caseDir);
 					await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+					expect(options).toMatchSnapshot("options");
 				});
 
 				it("as written", async () => {
@@ -132,9 +148,10 @@ describe("Incomplete types", () => {
 						dirname,
 						"cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/asWritten",
 					);
-					const { actualContent, expectedFilePath } =
+					const { actualContent, expectedFilePath, options } =
 						await runMutationTest(caseDir);
 					await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+					expect(options).toMatchSnapshot("options");
 				});
 			});
 		});
@@ -144,9 +161,10 @@ describe("Incomplete types", () => {
 				dirname,
 				"cases/fixes/incompleteTypes/reactTypes/reactPropsFromUses",
 			);
-			const { actualContent, expectedFilePath } =
+			const { actualContent, expectedFilePath, options } =
 				await runMutationTest(caseDir);
 			await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+			expect(options).toMatchSnapshot("options");
 		});
 
 		it("react props missing", async () => {
@@ -154,9 +172,10 @@ describe("Incomplete types", () => {
 				dirname,
 				"cases/fixes/incompleteTypes/reactTypes/reactPropsMissing",
 			);
-			const { actualContent, expectedFilePath } =
+			const { actualContent, expectedFilePath, options } =
 				await runMutationTest(caseDir);
 			await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+			expect(options).toMatchSnapshot("options");
 		});
 	});
 
@@ -165,8 +184,10 @@ describe("Incomplete types", () => {
 			dirname,
 			"cases/fixes/incompleteTypes/returnTypes",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("variable types", async () => {
@@ -174,7 +195,9 @@ describe("Incomplete types", () => {
 			dirname,
 			"cases/fixes/incompleteTypes/variableTypes",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/fixMissingProperties.test.ts
+++ b/test/fixMissingProperties.test.ts
@@ -9,7 +9,9 @@ describe("Missing properties", () => {
 			import.meta.dirname,
 			"./cases/fixes/missingProperties/missingPropertyAccesses",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	}, 10000);
 });

--- a/test/fixNoImplicitAny.test.ts
+++ b/test/fixNoImplicitAny.test.ts
@@ -9,17 +9,21 @@ describe("noImplicitAny", () => {
 			import.meta.dirname,
 			"cases/fixes/noImplicitAny/parameters",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
-	});
+		expect(options).toMatchSnapshot("options");
+	}, 7000);
 
 	it("property declarations", async () => {
 		const caseDir = path.join(
 			import.meta.dirname,
 			"cases/fixes/noImplicitAny/propertyDeclarations",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("variable declarations", async () => {
@@ -27,7 +31,9 @@ describe("noImplicitAny", () => {
 			import.meta.dirname,
 			"cases/fixes/noImplicitAny/variableDeclarations",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/fixNoImplicitThis.test.ts
+++ b/test/fixNoImplicitThis.test.ts
@@ -9,7 +9,9 @@ describe("noImplicitThis", () => {
 			import.meta.dirname,
 			"cases/fixes/noImplicitThis",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/fixNoInferableTypes.test.ts
+++ b/test/fixNoInferableTypes.test.ts
@@ -9,8 +9,10 @@ describe("No inferable types", () => {
 			import.meta.dirname,
 			"cases/fixes/noInferableTypes/parameters",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("property declarations", async () => {
@@ -18,8 +20,10 @@ describe("No inferable types", () => {
 			import.meta.dirname,
 			"cases/fixes/noInferableTypes/propertyDeclarations",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("variable declarations", async () => {
@@ -27,7 +31,9 @@ describe("No inferable types", () => {
 			import.meta.dirname,
 			"cases/fixes/noInferableTypes/variableDeclarations",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/fixStrictNonNullAssertions.test.ts
+++ b/test/fixStrictNonNullAssertions.test.ts
@@ -9,8 +9,10 @@ describe("strictNonNullAssertions", () => {
 			import.meta.dirname,
 			"cases/fixes/strictNonNullAssertions/binaryExpressions",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("callExpressions", async () => {
@@ -18,8 +20,10 @@ describe("strictNonNullAssertions", () => {
 			import.meta.dirname,
 			"cases/fixes/strictNonNullAssertions/callExpressions",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("objectLiterals", async () => {
@@ -27,8 +31,10 @@ describe("strictNonNullAssertions", () => {
 			import.meta.dirname,
 			"cases/fixes/strictNonNullAssertions/objectLiterals",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("propertyAccesses", async () => {
@@ -36,8 +42,10 @@ describe("strictNonNullAssertions", () => {
 			import.meta.dirname,
 			"cases/fixes/strictNonNullAssertions/propertyAccesses",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("returnTypes", async () => {
@@ -45,7 +53,9 @@ describe("strictNonNullAssertions", () => {
 			import.meta.dirname,
 			"cases/fixes/strictNonNullAssertions/returnTypes",
 		);
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/include.test.ts
+++ b/test/include.test.ts
@@ -6,13 +6,17 @@ import { runMutationTest } from "../src/tests/testSetup.js";
 describe("include", () => {
 	it("asterisk", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/include/asterisk");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 
 	it("directory", async () => {
 		const caseDir = path.join(import.meta.dirname, "cases/include/directory");
-		const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
 	});
 });

--- a/test/infiniteWaveDetection.test.ts
+++ b/test/infiniteWaveDetection.test.ts
@@ -8,6 +8,8 @@ test("Infinite wave detection", async () => {
 		import.meta.dirname,
 		"cases/infinite wave detection",
 	);
-	const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+	const { actualContent, expectedFilePath, options } =
+		await runMutationTest(caseDir);
 	await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+	expect(options).toMatchSnapshot("options");
 }, 50000);

--- a/test/postProcessing.test.ts
+++ b/test/postProcessing.test.ts
@@ -5,6 +5,8 @@ import { runMutationTest } from "../src/tests/testSetup.js";
 
 test("Post processing", async () => {
 	const caseDir = path.join(import.meta.dirname, "cases/post processing");
-	const { actualContent, expectedFilePath } = await runMutationTest(caseDir);
+	const { actualContent, expectedFilePath, options } =
+		await runMutationTest(caseDir);
 	await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+	expect(options).toMatchSnapshot("options");
 }, 50000);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1529
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken 🐕 

## Overview

Uses snapshots to see if there are changes how options are parsed. This will be useful when fixing #1529 