### PR TITLE
fix: fixes reading tsconfig and handling compilerOptions

### DIFF
--- a/src/options/loadPendingOptions.ts
+++ b/src/options/loadPendingOptions.ts
@@ -5,7 +5,7 @@ import { normalizeAndSlashify } from "../shared/paths.js";
 import { fillOutRawOptions } from "./fillOutRawOptions.js";
 import { findRawOptions } from "./findRawOptions.js";
 import { findComplaintForOptions } from "./optionVerification.js";
-import { parseRawCompilerOptions } from "./parseRawCompilerOptions.js";
+import { parseRawTsConfig } from "./parseRawCompilerOptions.js";
 import { PendingTypeStatOptions, RawTypeStatOptions } from "./types.js";
 
 /**
@@ -34,14 +34,14 @@ export const loadPendingOptions = async (
 	for (let i = 0; i < allRawOptions.length; i += 1) {
 		const rawOptions = allRawOptions[i];
 		const projectPath = getProjectPath(cwd, filePath, rawOptions);
-		const compilerOptions = await parseRawCompilerOptions(cwd, projectPath);
+		const tsConfig = await parseRawTsConfig(cwd, projectPath);
 
 		const filledOutOptions = fillOutRawOptions({
-			compilerOptions,
 			cwd,
 			output,
 			projectPath,
 			rawOptions,
+			tsConfig,
 		});
 		const complaint = findComplaintForOptions(filledOutOptions);
 		if (complaint) {

--- a/src/options/parsing/collectNoImplicitAny.ts
+++ b/src/options/parsing/collectNoImplicitAny.ts
@@ -3,16 +3,7 @@ import ts from "typescript";
 import { RawTypeStatOptions } from "../types.js";
 
 export const collectNoImplicitAny = (
-	compilerOptions: Readonly<ts.CompilerOptions>,
+	compilerOptions: Readonly<ts.CompilerOptions> | undefined,
 	rawOptions: RawTypeStatOptions,
-): boolean => {
-	if (rawOptions.fixes?.noImplicitAny !== undefined) {
-		return rawOptions.fixes.noImplicitAny;
-	}
-
-	if (compilerOptions.noImplicitAny !== undefined) {
-		return compilerOptions.noImplicitAny;
-	}
-
-	return false;
-};
+): boolean =>
+	rawOptions.fixes?.noImplicitAny || compilerOptions?.noImplicitAny || false;

--- a/src/options/parsing/collectNoImplicitThis.ts
+++ b/src/options/parsing/collectNoImplicitThis.ts
@@ -3,16 +3,7 @@ import ts from "typescript";
 import { RawTypeStatOptions } from "../types.js";
 
 export const collectNoImplicitThis = (
-	compilerOptions: Readonly<ts.CompilerOptions>,
+	compilerOptions: Readonly<ts.CompilerOptions> | undefined,
 	rawOptions: RawTypeStatOptions,
-): boolean => {
-	if (rawOptions.fixes?.noImplicitThis !== undefined) {
-		return rawOptions.fixes.noImplicitThis;
-	}
-
-	if (compilerOptions.noImplicitThis !== undefined) {
-		return compilerOptions.noImplicitThis;
-	}
-
-	return false;
-};
+): boolean =>
+	rawOptions.fixes?.noImplicitThis || compilerOptions?.noImplicitThis || false;

--- a/src/options/parsing/collectStrictNullChecks.ts
+++ b/src/options/parsing/collectStrictNullChecks.ts
@@ -3,33 +3,10 @@ import ts from "typescript";
 import { RawTypeStatTypeOptions } from "../types.js";
 
 export const collectStrictNullChecks = (
-	compilerOptions: Readonly<ts.CompilerOptions>,
+	compilerOptions: Readonly<ts.CompilerOptions> | undefined,
 	rawOptionTypes: RawTypeStatTypeOptions,
-) => {
-	const typeStrictNullChecks = rawOptionTypes.strictNullChecks;
-	const compilerStrictNullChecks = collectCompilerStrictNullChecks(
-		compilerOptions,
-		typeStrictNullChecks,
-	);
-
-	return { compilerStrictNullChecks, typeStrictNullChecks };
-};
-
-const collectCompilerStrictNullChecks = (
-	compilerOptions: Readonly<ts.CompilerOptions>,
-	typeStrictNullChecks: boolean | undefined,
-): boolean => {
-	if (typeStrictNullChecks !== undefined) {
-		return typeStrictNullChecks;
-	}
-
-	if (compilerOptions.strictNullChecks !== undefined) {
-		return compilerOptions.strictNullChecks;
-	}
-
-	if (compilerOptions.strict !== undefined) {
-		return compilerOptions.strict;
-	}
-
-	return false;
-};
+): boolean =>
+	rawOptionTypes.strictNullChecks ||
+	compilerOptions?.strictNullChecks ||
+	compilerOptions?.strict ||
+	false;

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -87,7 +87,7 @@ export interface BaseTypeStatOptions {
 	/**
 	 * Parsed TypeScript compiler options with relevant fields filled out.
 	 */
-	readonly compilerOptions: Readonly<TypeStatCompilerOptions>;
+	readonly compilerOptions: Readonly<ts.CompilerOptions>;
 
 	/**
 	 * Directives for file-level changes.
@@ -160,15 +160,6 @@ export interface TypeStatOptions extends BaseTypeStatOptions {
 	 */
 	readonly fileNames: readonly string[];
 }
-
-/**
- * Parsed TypeScript compiler options with relevant fields filled out.
- */
-export type TypeStatCompilerOptions = ts.CompilerOptions & {
-	noImplicitAny: boolean;
-	noImplicitThis: boolean;
-	strictNullChecks: boolean;
-};
 
 /**
  * Directives for file-level changes.

--- a/src/tests/testSetup.ts
+++ b/src/tests/testSetup.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { fillOutRawOptions } from "../options/fillOutRawOptions.js";
-import { parseRawCompilerOptions } from "../options/parseRawCompilerOptions.js";
+import { parseRawTsConfig } from "../options/parseRawCompilerOptions.js";
 import {
 	PendingTypeStatOptions,
 	RawTypeStatOptions,
@@ -44,7 +44,7 @@ export const runMutationTest = async (
 
 	const projectPath = path.join(dirPath, "tsconfig.json");
 
-	const compilerOptions = await parseRawCompilerOptions(dirPath, projectPath);
+	const tsConfig = await parseRawTsConfig(dirPath, projectPath);
 
 	const output = {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -58,11 +58,11 @@ export const runMutationTest = async (
 
 	for (const mutationOption of rawOptionsList) {
 		const pendingOptions = fillOutRawOptions({
-			compilerOptions,
 			cwd: dirPath,
 			output,
 			projectPath,
 			rawOptions: mutationOption,
+			tsConfig,
 		});
 
 		pendingOptionsList.push(pendingOptions);

--- a/test/__snapshots__/cleanups.test.ts.snap
+++ b/test/__snapshots__/cleanups.test.ts.snap
@@ -7,17 +7,11 @@ exports[`Cleanups > non-TypeErrors > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "esModuleInterop": true,
-        "strictNullChecks": true,
-        "resolveJsonModule": true
-      },
-      "files": [
-        "actual.ts"
-      ],
+      "esModuleInterop": true,
+      "strictNullChecks": true,
+      "resolveJsonModule": true,
       "noImplicitAny": false,
-      "noImplicitThis": false,
-      "strictNullChecks": false
+      "noImplicitThis": false
     },
     "files": {
       "above": "",
@@ -79,7 +73,9 @@ exports[`Cleanups > non-TypeErrors > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": true
+    }
   }
 ]"
 `;
@@ -91,15 +87,9 @@ exports[`Cleanups > suppressTypeErrors > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "strictNullChecks": true
-      },
-      "files": [
-        "actual.ts"
-      ],
+      "strictNullChecks": true,
       "noImplicitAny": false,
-      "noImplicitThis": false,
-      "strictNullChecks": false
+      "noImplicitThis": false
     },
     "files": {
       "above": "",
@@ -161,7 +151,9 @@ exports[`Cleanups > suppressTypeErrors > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": true
+    }
   }
 ]"
 `;

--- a/test/__snapshots__/customMutators.test.ts.snap
+++ b/test/__snapshots__/customMutators.test.ts.snap
@@ -7,9 +7,6 @@ exports[`Custom mutators > empty array > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -74,7 +71,9 @@ exports[`Custom mutators > empty array > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -86,10 +85,6 @@ exports[`Custom mutators > one mutator > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "include": [
-        "<rootDir>/actual.ts"
-      ],
-      "compileOnSave": false,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -133,7 +128,9 @@ exports[`Custom mutators > one mutator > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -145,9 +142,6 @@ exports[`Custom mutators > two mutators > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -192,7 +186,9 @@ exports[`Custom mutators > two mutators > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;

--- a/test/__snapshots__/files.test.ts.snap
+++ b/test/__snapshots__/files.test.ts.snap
@@ -7,9 +7,6 @@ exports[`files > addition above > options 1`] = `
       "suppressTypeErrors": false
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -74,7 +71,9 @@ exports[`files > addition above > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -86,9 +85,6 @@ exports[`files > addition below > options 1`] = `
       "suppressTypeErrors": false
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -153,7 +149,9 @@ exports[`files > addition below > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -165,9 +163,6 @@ exports[`files > both > options 1`] = `
       "suppressTypeErrors": false
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -232,7 +227,9 @@ exports[`files > both > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -244,9 +241,6 @@ exports[`files > empty addition > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -311,7 +305,9 @@ exports[`files > empty addition > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;

--- a/test/__snapshots__/filters.test.ts.snap
+++ b/test/__snapshots__/filters.test.ts.snap
@@ -7,9 +7,6 @@ exports[`filters > empty > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": true,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -88,9 +85,6 @@ exports[`filters > one > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": true,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -171,9 +165,6 @@ exports[`filters > two > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": true,
       "noImplicitThis": false,
       "strictNullChecks": true

--- a/test/__snapshots__/fixEnumAsArgument.test.ts.snap
+++ b/test/__snapshots__/fixEnumAsArgument.test.ts.snap
@@ -7,9 +7,6 @@ exports[`enum as argument > options 1`] = `
       "suppressTypeErrors": false
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -74,7 +71,9 @@ exports[`enum as argument > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;

--- a/test/__snapshots__/fixImportExtensions.test.ts.snap
+++ b/test/__snapshots__/fixImportExtensions.test.ts.snap
@@ -7,11 +7,6 @@ exports[`import extensions > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts",
-        "foundDirect.ts",
-        "foundIndirect/index.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -76,7 +71,9 @@ exports[`import extensions > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;

--- a/test/__snapshots__/fixIncompleteTypes.test.ts.snap
+++ b/test/__snapshots__/fixIncompleteTypes.test.ts.snap
@@ -7,10 +7,6 @@ exports[`Incomplete types > Implicit generics > incomplete implicit class generi
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts",
-        "react-like.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -75,7 +71,9 @@ exports[`Incomplete types > Implicit generics > incomplete implicit class generi
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -87,9 +85,6 @@ exports[`Incomplete types > Implicit generics > incomplete implicit variable gen
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -154,7 +149,9 @@ exports[`Incomplete types > Implicit generics > incomplete implicit variable gen
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -166,9 +163,6 @@ exports[`Incomplete types > Interface or type literal generics > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -233,7 +227,9 @@ exports[`Incomplete types > Interface or type literal generics > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -245,9 +241,6 @@ exports[`Incomplete types > Non-generic Interface as Type argument > options 1`]
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -312,7 +305,9 @@ exports[`Incomplete types > Non-generic Interface as Type argument > options 1`]
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -324,13 +319,8 @@ exports[`Incomplete types > React types > React props from prop types > Optional
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -395,7 +385,9 @@ exports[`Incomplete types > React types > React props from prop types > Optional
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -407,13 +399,8 @@ exports[`Incomplete types > React types > React props from prop types > Optional
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -478,7 +465,9 @@ exports[`Incomplete types > React types > React props from prop types > Optional
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -490,13 +479,8 @@ exports[`Incomplete types > React types > React props from prop types > Optional
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -561,7 +545,9 @@ exports[`Incomplete types > React types > React props from prop types > Optional
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -573,14 +559,9 @@ exports[`Incomplete types > React types > React props from prop types > all > op
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "esModuleInterop": true,
-        "jsx": "react",
-        "target": "ES2022"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "esModuleInterop": true,
+      "jsx": 2,
+      "target": 9,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -645,7 +626,9 @@ exports[`Incomplete types > React types > React props from prop types > all > op
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -657,14 +640,9 @@ exports[`Incomplete types > React types > not react props > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -729,7 +707,9 @@ exports[`Incomplete types > React types > not react props > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -741,14 +721,9 @@ exports[`Incomplete types > React types > react prop functions from calls > opti
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -813,7 +788,9 @@ exports[`Incomplete types > React types > react prop functions from calls > opti
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -825,13 +802,8 @@ exports[`Incomplete types > React types > react props from later assignments > o
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -896,7 +868,9 @@ exports[`Incomplete types > React types > react props from later assignments > o
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -908,14 +882,9 @@ exports[`Incomplete types > React types > react props from prop uses > options 1
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -980,7 +949,9 @@ exports[`Incomplete types > React types > react props from prop uses > options 1
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -992,14 +963,9 @@ exports[`Incomplete types > React types > react props missing > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
-        "jsx": "react"
-      },
-      "files": [
-        "actual.tsx"
-      ],
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "jsx": 2,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -1064,7 +1030,9 @@ exports[`Incomplete types > React types > react props missing > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -1076,9 +1044,6 @@ exports[`Incomplete types > parameter types > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -1143,7 +1108,9 @@ exports[`Incomplete types > parameter types > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -1155,9 +1122,6 @@ exports[`Incomplete types > property declaration types > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -1222,7 +1186,9 @@ exports[`Incomplete types > property declaration types > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -1234,12 +1200,7 @@ exports[`Incomplete types > return types > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "target": "ES2020"
-      },
-      "files": [
-        "actual.ts"
-      ],
+      "target": 7,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -1318,9 +1279,6 @@ exports[`Incomplete types > variable types > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true

--- a/test/__snapshots__/fixMissingProperties.test.ts.snap
+++ b/test/__snapshots__/fixMissingProperties.test.ts.snap
@@ -7,9 +7,6 @@ exports[`Missing properties > missing property accesses > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true

--- a/test/__snapshots__/fixNoImplicitAny.test.ts.snap
+++ b/test/__snapshots__/fixNoImplicitAny.test.ts.snap
@@ -7,9 +7,6 @@ exports[`noImplicitAny > parameters > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": true,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -88,9 +85,6 @@ exports[`noImplicitAny > property declarations > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -169,9 +163,6 @@ exports[`noImplicitAny > variable declarations > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true

--- a/test/__snapshots__/fixNoImplicitThis.test.ts.snap
+++ b/test/__snapshots__/fixNoImplicitThis.test.ts.snap
@@ -7,9 +7,6 @@ exports[`noImplicitThis > noImplicitThis > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": true,
       "strictNullChecks": true

--- a/test/__snapshots__/fixNoInferableTypes.test.ts.snap
+++ b/test/__snapshots__/fixNoInferableTypes.test.ts.snap
@@ -7,9 +7,6 @@ exports[`No inferable types > parameters > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -88,9 +85,6 @@ exports[`No inferable types > property declarations > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -169,9 +163,6 @@ exports[`No inferable types > variable declarations > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true

--- a/test/__snapshots__/fixStrictNonNullAssertions.test.ts.snap
+++ b/test/__snapshots__/fixStrictNonNullAssertions.test.ts.snap
@@ -7,15 +7,9 @@ exports[`strictNonNullAssertions > binaryExpressions > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "strictNullChecks": true
-      },
-      "files": [
-        "actual.ts"
-      ],
+      "strictNullChecks": true,
       "noImplicitAny": false,
-      "noImplicitThis": false,
-      "strictNullChecks": true
+      "noImplicitThis": false
     },
     "files": {
       "above": "",
@@ -91,9 +85,6 @@ exports[`strictNonNullAssertions > callExpressions > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -172,9 +163,6 @@ exports[`strictNonNullAssertions > objectLiterals > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -253,9 +241,6 @@ exports[`strictNonNullAssertions > propertyAccesses > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "files": [
-        "actual.ts"
-      ],
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": true
@@ -334,15 +319,9 @@ exports[`strictNonNullAssertions > returnTypes > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "compilerOptions": {
-        "strictNullChecks": true
-      },
-      "files": [
-        "actual.ts"
-      ],
+      "strictNullChecks": true,
       "noImplicitAny": false,
-      "noImplicitThis": false,
-      "strictNullChecks": true
+      "noImplicitThis": false
     },
     "files": {
       "above": "",

--- a/test/__snapshots__/include.test.ts.snap
+++ b/test/__snapshots__/include.test.ts.snap
@@ -7,12 +7,6 @@ exports[`include > asterisk > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "include": [
-        "<rootDir>/actual.ts",
-        "<rootDir>/expected.ts",
-        "<rootDir>/original.ts"
-      ],
-      "compileOnSave": false,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -58,7 +52,9 @@ exports[`include > asterisk > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;
@@ -70,12 +66,6 @@ exports[`include > directory > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "include": [
-        "<rootDir>/actual.ts",
-        "<rootDir>/expected.ts",
-        "<rootDir>/original.ts"
-      ],
-      "compileOnSave": false,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -121,7 +111,9 @@ exports[`include > directory > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;

--- a/test/__snapshots__/infiniteWaveDetection.test.ts.snap
+++ b/test/__snapshots__/infiniteWaveDetection.test.ts.snap
@@ -7,10 +7,6 @@ exports[`Infinite wave detection > options 1`] = `
       "suppressTypeErrors": true
     },
     "compilerOptions": {
-      "include": [
-        "<rootDir>/actual.ts"
-      ],
-      "compileOnSave": false,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -54,7 +50,9 @@ exports[`Infinite wave detection > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;

--- a/test/__snapshots__/postProcessing.test.ts.snap
+++ b/test/__snapshots__/postProcessing.test.ts.snap
@@ -7,10 +7,6 @@ exports[`Post processing > options 1`] = `
       "suppressTypeErrors": false
     },
     "compilerOptions": {
-      "include": [
-        "<rootDir>/actual.ts"
-      ],
-      "compileOnSave": false,
       "noImplicitAny": false,
       "noImplicitThis": false,
       "strictNullChecks": false
@@ -83,7 +79,9 @@ exports[`Post processing > options 1`] = `
       ]
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": false
+    }
   }
 ]"
 `;

--- a/test/cases/cleanups/nonTypeErrors/expected.ts
+++ b/test/cases/cleanups/nonTypeErrors/expected.ts
@@ -1,6 +1,4 @@
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import ts from "typescript";
-// @ts-expect-error -- TODO: Cannot find module './typestat.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
 import config from "./typestat.json";
 
 (function () {})();

--- a/test/cases/cleanups/suppressTypeErrors/expected.ts
+++ b/test/cases/cleanups/suppressTypeErrors/expected.ts
@@ -7,6 +7,6 @@ import config from "./typestat.json";
 // @ts-expect-error -- TODO: Type 'number' is not assignable to type 'string'.
 	let incorrectSingle: string = 0;
 
-// @ts-expect-error -- TODO: Property 'replace' does not exist on type 'undefined[]'. Property 'values' does not exist on type '{}'.
+// @ts-expect-error -- TODO: Property 'replace' does not exist on type 'never[]'. Property 'values' does not exist on type '{}'.
 	let incorrectMultiple: string = [].replace() + {}.values();
 })();

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromLaterAssignments/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromLaterAssignments/expected.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import React from "react";
 
 (function () {
@@ -9,12 +8,10 @@ text?: string;
 
 	class ClassComponent extends React.Component<ClassComponentProps> {
 		render() {
-// @ts-expect-error -- TODO: Property 'props' does not exist on type 'ClassComponent'.
 			return this.props.text;
 		}
 	}
 
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 	const renderClassComponent = (text: string) => <ClassComponent text={text} />;
 
 	type FunctionComponentProps = {
@@ -24,13 +21,11 @@ texts?: string[];
 
 	class FunctionComponent extends React.Component<FunctionComponentProps> {
 		render() {
-// @ts-expect-error -- TODO: Property 'props' does not exist on type 'FunctionComponent'.
 			return this.props.texts.join("");
 		}
 	}
 
 	const renderFunctionComponent = (texts: string[]) => (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<FunctionComponent texts={texts} />
 	);
 
@@ -42,7 +37,6 @@ texts?: string[];
 	class WithFunctions extends React.Component<WithFunctionsProps> {}
 
 	const withFunctions = (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<WithFunctions
 			returnsBoolean={() => false}
 			returnsStringOrNumber={() => 0}

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/all/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/all/expected.tsx
@@ -1,6 +1,4 @@
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import React from "react";
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import PropTypes from "prop-types";
 
 (function () {
@@ -131,7 +129,6 @@ interface LaterAssignedComponentProps {
 		}
 	}
 
-// @ts-expect-error -- TODO: Property 'propTypes' does not exist on type 'typeof LaterAssignedComponent'.
 	LaterAssignedComponent.propTypes = {
 		string: PropTypes.string,
 		stringRequired: PropTypes.string.isRequired,
@@ -144,12 +141,10 @@ interface GreetingProps {
 
 	class Greeting extends React.Component<GreetingProps> {
 		render() {
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided. Property 'props' does not exist on type 'Greeting'.
 			return <h1>Hello, {this.props.name}</h1>;
 		}
 	}
 
-// @ts-expect-error -- TODO: Property 'propTypes' does not exist on type 'typeof Greeting'.
 	Greeting.propTypes = {
 		name: PropTypes.string,
 	};
@@ -160,7 +155,6 @@ interface HelloWorldComponentProps {
 
 
 	function HelloWorldComponent({ name }: HelloWorldComponentProps) {
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		return <div>Hello, {name}</div>;
 	}
 
@@ -174,7 +168,6 @@ interface HeadingProps {
 
 
 	function Heading({ text }: HeadingProps) {
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		return <h1>{text}</h1>;
 	}
 	Heading.propTypes = {
@@ -186,7 +179,6 @@ interface HeadingProps {
 
 	const LegendImage = function (props: any) {
 		return (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 			<img
 				{...props}
 				style={{ display: "none", marginTop: "4px" }}

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/alwaysOptional/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/alwaysOptional/expected.tsx
@@ -1,6 +1,4 @@
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import React from "react";
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import PropTypes from "prop-types";
 
 (function () {

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/alwaysRequired/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/alwaysRequired/expected.tsx
@@ -1,6 +1,4 @@
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import React from "react";
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import PropTypes from "prop-types";
 
 (function () {

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/asWritten/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromPropTypes/optionality/asWritten/expected.tsx
@@ -1,6 +1,4 @@
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import React from "react";
-// @ts-expect-error -- TODO: This module can only be default-imported using the 'esModuleInterop' flag
 import PropTypes from "prop-types";
 
 (function () {

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromUses/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsFromUses/expected.tsx
@@ -30,13 +30,11 @@ import * as React from "react";
 			useTakesString(takesStringCall);
 
 			const withReturnsString = (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 				<WithReturnsString
 					takeTakesNumberReturnsString={takesNumberReturnsStringJsx}
 				/>
 			);
 
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 			return <span />;
 		}
 	}

--- a/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/expected.tsx
+++ b/test/cases/fixes/incompleteTypes/reactTypes/reactPropsMissing/expected.tsx
@@ -19,37 +19,22 @@ isNumberOrStringArray?: number[] | string[] | (string | number)[];
 isObject?: SomeValue;
 }
 
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 	const ManyProps = (props: ManyPropsProps) => <div />;
 
 	const renderManyProps = () => [
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isBoolean />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumber={0} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isString="" />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumbers={1} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumbers={2} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isStrings="a" />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isStrings="b" />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumberOrString={3} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumberOrString="c" />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumberOrStringArray={[3]} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumberOrStringArray={["c"]} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isNumberOrStringArray={[3, "c"]} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isObject={someValue} />,
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<ManyProps always isObject={someValue} />,
 	];
 
@@ -59,12 +44,10 @@ prop: number[];
 
 	const SinglePropArrowFunction = ({ prop }: SinglePropArrowFunctionProps) => {
 		console.log(prop);
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		return <div />;
 	};
 
 	const renderSinglePropArrowFunction = () => (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<SinglePropArrowFunction prop={[1, 2, 3]} />
 	);
 
@@ -74,12 +57,10 @@ prop: number[];
 
 	const SinglePropFunctionExpressionAnonymous = function ({ prop }: SinglePropFunctionExpressionAnonymousProps) {
 		console.log(prop);
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		return <div />;
 	};
 
 	const renderSinglePropFunctionExpressionAnonymous = () => (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<SinglePropFunctionExpressionAnonymous prop={[1, 2, 3]} />
 	);
 
@@ -91,12 +72,10 @@ prop: number[];
 		prop,
 	}: FunctionExpressionNamedProps) {
 		console.log(prop);
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		return <div />;
 	};
 
 	const renderSinglePropFunctionExpressionNamed = () => (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<SinglePropFunctionExpressionNamed prop={[1, 2, 3]} />
 	);
 
@@ -106,13 +85,11 @@ prop: number[];
 
 	const SinglePropClassExpression = class extends React.Component<SinglePropClassExpressionProps> {
 		render() {
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 			return <div />;
 		}
 	};
 
 	const renderSinglePropClassExpression = () => (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<SinglePropClassExpression prop={[1, 2, 3]} />
 	);
 
@@ -122,13 +99,11 @@ prop: number[];
 
 	class SinglePropClassDeclaration extends React.Component<SinglePropClassDeclarationProps> {
 		render() {
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 			return <div />;
 		}
 	}
 
 	const renderSinglePropClassDeclaration = () => (
-// @ts-expect-error -- TODO: Cannot use JSX unless the '--jsx' flag is provided.
 		<SinglePropClassDeclaration prop={[1, 2, 3]} />
 	);
 })();

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -85,19 +85,19 @@
 		return "";
 	};
 
-// @ts-expect-error -- TODO: Type 'boolean | Promise<boolean>' is not a valid async function return type in ES5 because it does not refer to a Promise-compatible constructor value.
+// @ts-expect-error -- TODO: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<boolean>'?
 	async function navigateTo(): Promise<boolean> | boolean {
 		return await new Promise(() => "");
 	}
 
 	function navigateByUrl(url: string): Promise<boolean>;
 
-// @ts-expect-error -- TODO: Function implementation name must be 'navigateByUrl'. Type 'boolean | Promise<boolean>' is not a valid async function return type in ES5 because it does not refer to a Promise-compatible constructor value.
+// @ts-expect-error -- TODO: Function implementation name must be 'navigateByUrl'. The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<boolean>'?
 	async function navigateTo3(): Promise<boolean> | boolean {
 		return await navigateByUrl("");
 	}
 
-// @ts-expect-error -- TODO: Type 'boolean | Promise<boolean>' is not a valid async function return type in ES5 because it does not refer to a Promise-compatible constructor value.
+// @ts-expect-error -- TODO: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<boolean>'?
 	async function navigateTo2(): Promise<boolean> | boolean {
 		const navigated = await navigateByUrl("");
 		return navigated;
@@ -116,7 +116,6 @@
 	};
 
 	const returnsBigintOrNumber = (): number | bigint => {
-// @ts-expect-error -- TODO: BigInt literals are not available when targeting lower than ES2020.
 		return 123n;
 	};
 

--- a/test/cases/fixes/strictNonNullAssertions/callExpressions/expected.ts
+++ b/test/cases/fixes/strictNonNullAssertions/callExpressions/expected.ts
@@ -50,6 +50,7 @@
 	takesString(("" as string | undefined)!);
 	takesString(("" as string | null | undefined)!);
 
+	// test adds `!` to value here, but it has no effect
 	let emptyExplicitSibling: undefined = undefined!;
 	let emptyImplicitSibling = undefined!;
 	let emptyExplicitChild: undefined = undefined;

--- a/test/cases/fixes/strictNonNullAssertions/callExpressions/original.ts
+++ b/test/cases/fixes/strictNonNullAssertions/callExpressions/original.ts
@@ -50,6 +50,7 @@
 	takesString("" as string | undefined);
 	takesString("" as string | null | undefined);
 
+	// test adds `!` to value here, but it has no effect
 	let emptyExplicitSibling: undefined = undefined;
 	let emptyImplicitSibling = undefined;
 	let emptyExplicitChild: undefined = undefined;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1532 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- Fixes reading `tsconfig` and handling the values.
    - This can be seen in the snapshot files, where values for `compilerOptions` have been changed.
- Options from `typestat.json` should not disable `noImplicitAny` or `noImplicitThis` if they are enabled in `tsconfig`.