### PR TITLE
chore: use ts-api-utils or typescript for symbol kind checks

### DIFF
--- a/src/mutations/codeFixes/addMissingProperty.ts
+++ b/src/mutations/codeFixes/addMissingProperty.ts
@@ -1,5 +1,5 @@
 import { Mutation } from "automutate";
-import { isEqualsToken, isThisKeyword } from "ts-api-utils";
+import * as tsutils from "ts-api-utils";
 import ts from "typescript";
 
 import { FileMutationsRequest } from "../../shared/fileMutator.js";
@@ -32,8 +32,8 @@ export const getMissingPropertyMutations = (
  */
 const nodeIsSettingThisMember = (node: ts.PropertyAccessExpression): boolean =>
 	ts.isBinaryExpression(node.parent) &&
-	isEqualsToken(node.parent.operatorToken) &&
-	isThisKeyword(node.expression);
+	tsutils.isEqualsToken(node.parent.operatorToken) &&
+	tsutils.isThisKeyword(node.expression);
 
 /**
  * Uses a requesting language service to get missing property code fixes for a type of node.

--- a/src/mutations/codeFixes/addMissingProperty.ts
+++ b/src/mutations/codeFixes/addMissingProperty.ts
@@ -1,4 +1,5 @@
 import { Mutation } from "automutate";
+import { isEqualsToken, isThisKeyword } from "ts-api-utils";
 import ts from "typescript";
 
 import { FileMutationsRequest } from "../../shared/fileMutator.js";
@@ -31,8 +32,8 @@ export const getMissingPropertyMutations = (
  */
 const nodeIsSettingThisMember = (node: ts.PropertyAccessExpression): boolean =>
 	ts.isBinaryExpression(node.parent) &&
-	node.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-	node.expression.kind === ts.SyntaxKind.ThisKeyword;
+	isEqualsToken(node.parent.operatorToken) &&
+	isThisKeyword(node.expression);
 
 /**
  * Uses a requesting language service to get missing property code fixes for a type of node.

--- a/src/mutations/codeFixes/noImplicitAny.ts
+++ b/src/mutations/codeFixes/noImplicitAny.ts
@@ -44,10 +44,7 @@ export const getNoImplicitAnyMutations = (
 	// (TypeScript will still suggest a codefix to make a redundant inferred type)
 	if (ts.isParameter(node)) {
 		const nodeType = getTypeAtLocationIfNotError(request, node);
-		if (
-			nodeType === undefined ||
-			!tsutils.isTypeFlagSet(nodeType, ts.TypeFlags.Any)
-		) {
+		if (nodeType === undefined || !tsutils.isIntrinsicAnyType(nodeType)) {
 			return undefined;
 		}
 	}

--- a/src/mutations/collecting.ts
+++ b/src/mutations/collecting.ts
@@ -30,7 +30,7 @@ export const collectUsageFlagsAndSymbols = (
 	// If the declared type is the general 'any', then we assume all are missing
 	// Similarly, if it's a plain Function or Object, we'll want to replace its contents
 	if (
-		tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any) ||
+		tsutils.isIntrinsicAnyType(declaredType) ||
 		isKnownGlobalBaseType(declaredType)
 	) {
 		return {

--- a/src/mutations/collecting.ts
+++ b/src/mutations/collecting.ts
@@ -30,7 +30,7 @@ export const collectUsageFlagsAndSymbols = (
 	// If the declared type is the general 'any', then we assume all are missing
 	// Similarly, if it's a plain Function or Object, we'll want to replace its contents
 	if (
-		declaredType.flags & ts.TypeFlags.Any ||
+		tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any) ||
 		isKnownGlobalBaseType(declaredType)
 	) {
 		return {

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -26,7 +26,7 @@ export const createTypeAdditionMutation = (
 	allAssignedTypes: readonly ts.Type[],
 ): TextInsertMutation | TextSwapMutation | undefined => {
 	// Declared 'any' types inherently can't be incomplete
-	if (tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)) {
+	if (tsutils.isIntrinsicAnyType(declaredType)) {
 		return undefined;
 	}
 

--- a/src/mutations/expansions/eliminations.ts
+++ b/src/mutations/expansions/eliminations.ts
@@ -94,6 +94,6 @@ function anySignatureReturnsVoid(type: ts.Type) {
 	return type
 		.getCallSignatures()
 		.some((callSignature) =>
-			tsutils.isTypeFlagSet(callSignature.getReturnType(), ts.TypeFlags.Void),
+			tsutils.isIntrinsicVoidType(callSignature.getReturnType()),
 		);
 }

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitClassGenerics/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitClassGenerics/index.ts
@@ -6,10 +6,8 @@ import {
 	FileMutationsRequest,
 	FileMutator,
 } from "../../../../../shared/fileMutator.js";
-import {
-	getBaseClassDeclaration,
-	getClassExtendsExpression,
-} from "../../../../../shared/nodeExtensions.js";
+import { getBaseClassDeclaration } from "../../../../../shared/nodeExtensions.js";
+import { getClassExtendsType } from "../../../../../shared/nodes.js";
 import { collectMutationsFromNodes } from "../../../../collectMutationsFromNodes.js";
 import { addMissingTemplateTypes, addNewTypeNodes } from "../additions.js";
 import { findMissingTemplateTypes } from "../templateCollecting.js";
@@ -24,7 +22,7 @@ const visitClassLike = (
 	request: FileMutationsRequest,
 ): Mutation | undefined => {
 	// We'll want a class node that extends some base class
-	const extension = getClassExtendsExpression(node);
+	const extension = getClassExtendsType(node);
 	if (extension === undefined) {
 		return undefined;
 	}

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/createExplicitGenericType.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/createExplicitGenericType.ts
@@ -70,7 +70,7 @@ const allTypeArgumentTypesMatch = (
 	// If the implicit type has defaulted to any, ignore it (assume a non-match)
 	if (
 		originalType.typeArguments.some((typeArgument) =>
-			tsutils.isTypeFlagSet(typeArgument, ts.TypeFlags.Any),
+			tsutils.isIntrinsicAnyType(typeArgument),
 		)
 	) {
 		return false;
@@ -79,7 +79,7 @@ const allTypeArgumentTypesMatch = (
 	// If the implicit types are all unknown, assume a non-match for being unknown
 	if (
 		originalType.typeArguments.every((typeArgument) =>
-			tsutils.isTypeFlagSet(typeArgument, ts.TypeFlags.Unknown),
+			tsutils.isIntrinsicUnknownType(typeArgument),
 		)
 	) {
 		return false;

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
@@ -36,10 +36,7 @@ const visitPropertyDeclaration = (
 	// Collect types later assigned to the property, and types initially declared by or inferred on the property
 	const assignedTypes = collectPropertyAssignedTypes(node, request);
 	const declaredType = getTypeAtLocationIfNotError(request, node);
-	if (
-		declaredType === undefined ||
-		tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)
-	) {
+	if (declaredType === undefined || tsutils.isIntrinsicAnyType(declaredType)) {
 		return undefined;
 	}
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsMissing.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsMissing.ts
@@ -66,7 +66,7 @@ const collectComponentAttributeTypes = (
 ) => {
 	// Find all references to the node, if there are more than just the node itself
 	const references = request.fileInfoCache.getNodeReferencesAsNodes(
-		node.parent.kind === ts.SyntaxKind.VariableDeclaration ? node.parent : node,
+		ts.isVariableDeclaration(node.parent) ? node.parent : node,
 	);
 	if (references === undefined || references.length === 0) {
 		return undefined;

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
@@ -38,10 +38,7 @@ const visitFunctionWithBody = (
 ) => {
 	// Collect the type initially declared as returned
 	const declaredType = getTypeAtLocationIfNotError(request, node.type);
-	if (
-		declaredType === undefined ||
-		tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)
-	) {
+	if (declaredType === undefined || tsutils.isIntrinsicAnyType(declaredType)) {
 		return undefined;
 	}
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteVariableTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteVariableTypes/index.ts
@@ -35,17 +35,12 @@ const visitVariableDeclaration = (
 ): Mutation | undefined => {
 	// Collect types later assigned to the variable, and types initially declared by or inferred on the variable
 	const assignedTypes = collectVariableAssignedTypes(node, request);
-	if (
-		assignedTypes.some((type) => tsutils.isTypeFlagSet(type, ts.TypeFlags.Any))
-	) {
+	if (assignedTypes.some((type) => tsutils.isIntrinsicAnyType(type))) {
 		return undefined;
 	}
 
 	const declaredType = getTypeAtLocationIfNotError(request, node);
-	if (
-		declaredType === undefined ||
-		tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)
-	) {
+	if (declaredType === undefined || tsutils.isIntrinsicAnyType(declaredType)) {
 		return undefined;
 	}
 

--- a/src/mutators/builtIn/fixNoImplicitThis/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitThis/index.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { isThisExpression } from "ts-api-utils";
 
 import { getNoImplicitThisMutations } from "../../../mutations/codeFixes/noImplicitThis.js";
 import {
@@ -17,6 +17,3 @@ export const fixNoImplicitThis: FileMutator = (
 				getNoImplicitThisMutations,
 			)
 		: undefined;
-
-const isThisExpression = (node: ts.Node): node is ts.ThisExpression =>
-	node.kind === ts.SyntaxKind.ThisKeyword;

--- a/src/mutators/builtIn/fixNoImplicitThis/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitThis/index.ts
@@ -1,4 +1,4 @@
-import { isThisExpression } from "ts-api-utils";
+import * as tsutils from "ts-api-utils";
 
 import { getNoImplicitThisMutations } from "../../../mutations/codeFixes/noImplicitThis.js";
 import {
@@ -13,7 +13,7 @@ export const fixNoImplicitThis: FileMutator = (
 	request.options.fixes.noImplicitThis
 		? collectMutationsFromNodes(
 				request,
-				isThisExpression,
+				tsutils.isThisExpression,
 				getNoImplicitThisMutations,
 			)
 		: undefined;

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionBinaryExpressions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionBinaryExpressions/index.ts
@@ -33,10 +33,7 @@ const visitBinaryExpression = (
 	}
 
 	const declaredType = getTypeAtLocationIfNotError(request, node.left);
-	if (
-		declaredType === undefined ||
-		tsutils.isTypeFlagSet(declaredType, ts.TypeFlags.Any)
-	) {
+	if (declaredType === undefined || tsutils.isIntrinsicAnyType(declaredType)) {
 		return undefined;
 	}
 

--- a/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
+++ b/src/mutators/builtIn/fixStrictNonNullAssertions/fixStrictNonNullAssertionCallExpressions/index.ts
@@ -118,8 +118,7 @@ const collectArgumentMutation = (
 		);
 		if (declaringVariableInitializer !== undefined) {
 			// ...if the variable doesn't already have a ! after its initial value
-			return declaringVariableInitializer.kind ===
-				ts.SyntaxKind.NonNullExpression
+			return ts.isNonNullExpression(declaringVariableInitializer)
 				? undefined
 				: createNonNullAssertion(request, declaringVariableInitializer);
 		}

--- a/src/shared/comparisons.ts
+++ b/src/shared/comparisons.ts
@@ -1,9 +1,4 @@
-import {
-	isFalseKeyword,
-	isNullKeyword,
-	isTrueKeyword,
-	isUnionType,
-} from "ts-api-utils";
+import * as tsutils from "ts-api-utils";
 import ts from "typescript";
 
 import { FileMutationsRequest } from "./fileMutator.js";
@@ -22,10 +17,13 @@ export const declaredInitializedTypeNodeIsRedundant = (
 	// Most literals (e.g. `""`) have a corresponding keyword (e.g. `string`)
 	switch (declaration.kind) {
 		case ts.SyntaxKind.BooleanKeyword:
-			return isFalseKeyword(initializer) || isTrueKeyword(initializer);
+			return (
+				tsutils.isFalseKeyword(initializer) ||
+				tsutils.isTrueKeyword(initializer)
+			);
 
 		case ts.SyntaxKind.NullKeyword:
-			return isNullKeyword(initializer);
+			return tsutils.isNullKeyword(initializer);
 
 		case ts.SyntaxKind.NumberKeyword:
 			return ts.isNumericLiteral(initializer);
@@ -96,7 +94,9 @@ const declaredTypeIsEquivalent = (
 		typeChecker.isTypeAssignableTo(declaredType, initializedType) &&
 		typeChecker.isTypeAssignableTo(initializedType, declaredType) &&
 		// ...though, notably, declares union types trigger false positives against non-union initializations
-		!(isUnionType(declaredType) && !isUnionType(initializedType))
+		!(
+			tsutils.isUnionType(declaredType) && !tsutils.isUnionType(initializedType)
+		)
 	) {
 		return true;
 	}

--- a/src/shared/comparisons.ts
+++ b/src/shared/comparisons.ts
@@ -1,4 +1,9 @@
-import * as tsutils from "ts-api-utils";
+import {
+	isFalseKeyword,
+	isNullKeyword,
+	isTrueKeyword,
+	isUnionType,
+} from "ts-api-utils";
 import ts from "typescript";
 
 import { FileMutationsRequest } from "./fileMutator.js";
@@ -17,19 +22,16 @@ export const declaredInitializedTypeNodeIsRedundant = (
 	// Most literals (e.g. `""`) have a corresponding keyword (e.g. `string`)
 	switch (declaration.kind) {
 		case ts.SyntaxKind.BooleanKeyword:
-			return (
-				initializer.kind === ts.SyntaxKind.FalseKeyword ||
-				initializer.kind === ts.SyntaxKind.TrueKeyword
-			);
+			return isFalseKeyword(initializer) || isTrueKeyword(initializer);
 
 		case ts.SyntaxKind.NullKeyword:
-			return initializer.kind === ts.SyntaxKind.NullKeyword;
+			return isNullKeyword(initializer);
 
 		case ts.SyntaxKind.NumberKeyword:
-			return initializer.kind === ts.SyntaxKind.NumericLiteral;
+			return ts.isNumericLiteral(initializer);
 
 		case ts.SyntaxKind.StringKeyword:
-			return initializer.kind === ts.SyntaxKind.StringLiteral;
+			return ts.isStringLiteral(initializer);
 
 		// (except for `undefined`, which is an initializer one should never reassign)
 		case ts.SyntaxKind.UndefinedKeyword:
@@ -94,9 +96,7 @@ const declaredTypeIsEquivalent = (
 		typeChecker.isTypeAssignableTo(declaredType, initializedType) &&
 		typeChecker.isTypeAssignableTo(initializedType, declaredType) &&
 		// ...though, notably, declares union types trigger false positives against non-union initializations
-		!(
-			tsutils.isUnionType(declaredType) && !tsutils.isUnionType(initializedType)
-		)
+		!(isUnionType(declaredType) && !isUnionType(initializedType))
 	) {
 		return true;
 	}

--- a/src/shared/nodeExtensions.ts
+++ b/src/shared/nodeExtensions.ts
@@ -3,26 +3,6 @@ import ts from "typescript";
 import { FileMutationsRequest } from "./fileMutator.js";
 import { getTypeAtLocationIfNotError } from "./types.js";
 
-export const getClassExtendsExpression = (
-	node: ts.ClassLikeDeclaration,
-): ts.ExpressionWithTypeArguments | undefined => {
-	const { heritageClauses } = node;
-	if (heritageClauses === undefined) {
-		return undefined;
-	}
-
-	const classExtension = heritageClauses.find(
-		(clause) => clause.token === ts.SyntaxKind.ExtendsKeyword,
-	);
-	if (classExtension === undefined) {
-		return undefined;
-	}
-
-	return classExtension.types.length === 1
-		? classExtension.types[0]
-		: undefined;
-};
-
 export const getBaseClassDeclaration = (
 	request: FileMutationsRequest,
 	extension: ts.ExpressionWithTypeArguments,

--- a/src/shared/nodes.ts
+++ b/src/shared/nodes.ts
@@ -1,4 +1,4 @@
-import * as tsutils from "ts-api-utils";
+import { isBlockLike, isEqualsToken } from "ts-api-utils";
 import ts from "typescript";
 
 import { FileMutationsRequest } from "./fileMutator.js";
@@ -68,8 +68,7 @@ export const getParentOfKind = <TNode extends ts.Node = ts.Node>(
 export const isNodeAssigningBinaryExpression = (
 	node: ts.Node,
 ): node is ts.BinaryExpression =>
-	ts.isBinaryExpression(node) &&
-	node.operatorToken.kind === ts.SyntaxKind.EqualsToken;
+	ts.isBinaryExpression(node) && isEqualsToken(node.operatorToken);
 
 /**
  * Gets a variable initializer for an expression, if one exists.
@@ -117,7 +116,7 @@ export const getExpressionWithin = (node: ts.Node) =>
 export const getCloseAncestorCallOrNewExpression = (
 	node: ts.Node,
 ): ts.CallExpression | ts.NewExpression | undefined => {
-	if (ts.isSourceFile(node.parent) || tsutils.isBlockLike(node)) {
+	if (ts.isSourceFile(node.parent) || isBlockLike(node)) {
 		return undefined;
 	}
 

--- a/src/shared/nodes.ts
+++ b/src/shared/nodes.ts
@@ -1,4 +1,4 @@
-import { isBlockLike, isEqualsToken } from "ts-api-utils";
+import * as tsutils from "ts-api-utils";
 import ts from "typescript";
 
 import { FileMutationsRequest } from "./fileMutator.js";
@@ -68,7 +68,7 @@ export const getParentOfKind = <TNode extends ts.Node = ts.Node>(
 export const isNodeAssigningBinaryExpression = (
 	node: ts.Node,
 ): node is ts.BinaryExpression =>
-	ts.isBinaryExpression(node) && isEqualsToken(node.operatorToken);
+	ts.isBinaryExpression(node) && tsutils.isEqualsToken(node.operatorToken);
 
 /**
  * Gets a variable initializer for an expression, if one exists.
@@ -116,7 +116,7 @@ export const getExpressionWithin = (node: ts.Node) =>
 export const getCloseAncestorCallOrNewExpression = (
 	node: ts.Node,
 ): ts.CallExpression | ts.NewExpression | undefined => {
-	if (ts.isSourceFile(node.parent) || isBlockLike(node)) {
+	if (ts.isSourceFile(node.parent) || tsutils.isBlockLike(node)) {
 		return undefined;
 	}
 

--- a/src/shared/transforms.ts
+++ b/src/shared/transforms.ts
@@ -1,3 +1,4 @@
+import { isNullKeyword, isUndefinedKeyword } from "ts-api-utils";
 import ts from "typescript";
 
 export type KnownTypeLiteralNode =
@@ -24,11 +25,11 @@ export const transformLiteralToTypeLiteralNode = (
 		);
 	}
 
-	if (node.kind === ts.SyntaxKind.NullKeyword) {
+	if (isNullKeyword(node)) {
 		return ts.factory.createLiteralTypeNode(ts.factory.createNull());
 	}
 
-	if (node.kind === ts.SyntaxKind.UndefinedKeyword) {
+	if (isUndefinedKeyword(node)) {
 		return ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
 	}
 

--- a/src/shared/transforms.ts
+++ b/src/shared/transforms.ts
@@ -1,4 +1,4 @@
-import { isNullKeyword, isUndefinedKeyword } from "ts-api-utils";
+import * as tsutils from "ts-api-utils";
 import ts from "typescript";
 
 export type KnownTypeLiteralNode =
@@ -25,11 +25,11 @@ export const transformLiteralToTypeLiteralNode = (
 		);
 	}
 
-	if (isNullKeyword(node)) {
+	if (tsutils.isNullKeyword(node)) {
 		return ts.factory.createLiteralTypeNode(ts.factory.createNull());
 	}
 
-	if (isUndefinedKeyword(node)) {
+	if (tsutils.isUndefinedKeyword(node)) {
 		return ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
 	}
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,7 +1,7 @@
+import * as tsutils from "ts-api-utils";
 import ts from "typescript";
 
 import { FileMutationsRequest } from "./fileMutator.js";
-import { isIntrinsicNameType } from "./typeNodes.js";
 
 /**
  * @returns Whether the type has `localTypeParameters`, such as the built-in Map and Array definitions.
@@ -68,7 +68,5 @@ export const getTypeAtLocationIfNotErrorWithChecker = (
 
 	const type = typeChecker.getTypeAtLocation(node);
 
-	return isIntrinsicNameType(type) && type.intrinsicName === "error"
-		? undefined
-		: type;
+	return tsutils.isIntrinsicErrorType(type) ? undefined : type;
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1544
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken :octocat: 

## Overview

Let's use existing checks from `ts-api-utils` and `typescript` when they exists there. 

Priority is to use checks from Typescript first, and then from ts-api-utils. 

There was duplicated function, and I removed in same go: `getClassExtendsExpression` and `getClassExtendsType`. I can remove this change though and send it separately, but feels too trivial to have it's own task & PR :) 