### PR TITLE
chore(deps): update dependency eslint-plugin-perfectionist to v2.10.0 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 0.13.1(eslint@8.57.0)(jsonc-eslint-parser@2.4.0)
       eslint-plugin-perfectionist:
         specifier: ^2.7.0
-        version: 2.8.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 2.10.0(eslint@8.57.0)(typescript@5.4.5)
       eslint-plugin-regexp:
         specifier: ^2.3.0
         version: 2.5.0(eslint@8.57.0)
@@ -1478,8 +1478,8 @@ packages:
       eslint: '>=8.0.0'
       jsonc-eslint-parser: ^2.0.0
 
-  eslint-plugin-perfectionist@2.8.0:
-    resolution: {integrity: sha512-XBjQ4ctU1rOzQ4bFJoUowe8XdsIIz42JqNrouFlae1TO78HjoyYBaRP8+gAHDDQCSdHY10pbChyzlJeBA6D51w==}
+  eslint-plugin-perfectionist@2.10.0:
+    resolution: {integrity: sha512-P+tdrkHeMWBc55+DZsoDOAftV1WCsEoHaKm6JC7zajFus/syfT4vUPBFb3atGFSuyaVnGQGHlcKpP9X3Q0gH/w==}
     peerDependencies:
       astro-eslint-parser: ^0.16.0
       eslint: '>=8.0.0'
@@ -4203,9 +4203,9 @@ snapshots:
       sort-package-json: 1.57.0
       validate-npm-package-name: 5.0.0
 
-  eslint-plugin-perfectionist@2.8.0(eslint@8.57.0)(typescript@5.4.5):
+  eslint-plugin-perfectionist@2.10.0(eslint@8.57.0)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       minimatch: 9.0.4
       natural-compare-lite: 1.4.0

--- a/src/mutations/codeFixes/noImplicitAny.ts
+++ b/src/mutations/codeFixes/noImplicitAny.ts
@@ -12,10 +12,10 @@ export type NoImplicitAnyNode =
 	| ts.PropertyDeclaration
 	| ts.VariableDeclaration;
 
-export type NoImplicitAnyNodeToBeFixed = NoImplicitAnyNode & {
+export type NoImplicitAnyNodeToBeFixed = {
 	initializer: undefined;
 	type: undefined;
-};
+} & NoImplicitAnyNode;
 
 /**
  * Error codes for the TypeScript language service to get --noImplicitAny code fixes.

--- a/src/mutations/renames/isRequireToJsFile.ts
+++ b/src/mutations/renames/isRequireToJsFile.ts
@@ -1,8 +1,8 @@
 import ts from "typescript";
 
-export type LocalImplicitRequireCallExpression = ts.CallExpression & {
+export type LocalImplicitRequireCallExpression = {
 	arguments: [ts.StringLiteral];
-};
+} & ts.CallExpression;
 
 export const isRequireToJsFile = (
 	node: ts.Node,

--- a/src/mutators/builtIn/fixImportExtensions/index.ts
+++ b/src/mutators/builtIn/fixImportExtensions/index.ts
@@ -10,12 +10,9 @@ import {
 import { getTypeAtLocationIfNotError } from "../../../shared/types.js";
 import { collectMutationsFromNodes } from "../../collectMutationsFromNodes.js";
 
-type ExtensionlessExportOrImport = (
-	| ts.ExportDeclaration
-	| ts.ImportDeclaration
-) & {
+type ExtensionlessExportOrImport = {
 	moduleSpecifier: ts.StringLiteral;
-};
+} & (ts.ExportDeclaration | ts.ImportDeclaration);
 
 export const fixImportExtensions: FileMutator = (
 	request: FileMutationsRequest,

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/getGenericClassDetails.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/getGenericClassDetails.ts
@@ -31,9 +31,9 @@ export interface GenericClassDetails {
 	typeParameterNames: readonly string[];
 }
 
-export type ParameterTypeNode = ts.TypeNode & {
+export type ParameterTypeNode = {
 	parent: ts.ParameterDeclaration;
-};
+} & ts.TypeNode;
 
 export interface ParameterTypeNodeSummary {
 	parameterName: string;

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/implicitGenericTypes.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteImplicitGenerics/fixIncompleteImplicitVariableGenerics/implicitGenericTypes.ts
@@ -1,9 +1,9 @@
 import ts from "typescript";
 
-export type VariableWithImplicitGeneric = ts.VariableDeclaration & {
+export type VariableWithImplicitGeneric = {
 	initializer: GenericCapableInitializer;
 	type: undefined;
-};
+} & ts.VariableDeclaration;
 
 type GenericCapableInitializer = ts.ArrayLiteralExpression | ts.NewExpression;
 

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteParameterTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteParameterTypes/index.ts
@@ -24,7 +24,7 @@ export const fixIncompleteParameterTypes: FileMutator = (
 
 const isParameterWithType = (
 	node: ts.Node,
-): node is ts.ParameterDeclaration & NodeWithType =>
+): node is NodeWithType & ts.ParameterDeclaration =>
 	ts.isParameter(node) && isNodeWithType(node);
 
 const visitParameterDeclaration = (

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompletePropertyDeclarationTypes/index.ts
@@ -26,7 +26,7 @@ export const fixIncompletePropertyDeclarationTypes: FileMutator = (
 
 const isPropertyDeclarationWithType = (
 	node: ts.Node,
-): node is ts.PropertyDeclaration & NodeWithType =>
+): node is NodeWithType & ts.PropertyDeclaration =>
 	ts.isPropertyDeclaration(node) && isNodeWithType(node);
 
 const visitPropertyDeclaration = (

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/getPropTypesValue.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/fixReactPropsFromPropTypes/propTypes/getPropTypesValue.ts
@@ -3,13 +3,13 @@ import ts from "typescript";
 
 import { ReactComponentNode } from "../../reactFiltering/isReactComponentNode.js";
 
-type PropTypesMember = ts.PropertyDeclaration & {
+type PropTypesMember = {
 	initializer: ts.ObjectLiteralExpression;
 	name: {
 		kind: ts.SyntaxKind.Identifier;
 		text: "propTypes";
 	};
-};
+} & ts.PropertyDeclaration;
 
 /**
  * @returns Whether a node is a `propTypes` class member with an object literal value.

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReactTypes/reactFiltering/isReactComponentNode.ts
@@ -6,12 +6,9 @@ export type ReactComponentNode =
 	| ReactClassComponentNode
 	| ReactFunctionalComponentNode;
 
-export type ReactClassComponentNode = (
-	| ts.ClassDeclaration
-	| ts.ClassExpression
-) & {
+export type ReactClassComponentNode = {
 	heritageClauses: ts.NodeArray<ts.HeritageClause>;
-};
+} & (ts.ClassDeclaration | ts.ClassExpression);
 
 export type ReactFunctionalComponentNode =
 	| ts.ArrowFunction

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteVariableTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteVariableTypes/index.ts
@@ -26,7 +26,7 @@ export const fixIncompleteVariableTypes: FileMutator = (
 
 const isNodeVariableDeclarationWithType = (
 	node: ts.Node,
-): node is ts.VariableDeclaration & NodeWithType =>
+): node is NodeWithType & ts.VariableDeclaration =>
 	ts.isVariableDeclaration(node) && isNodeWithType(node);
 
 const visitVariableDeclaration = (

--- a/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyParameters/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyParameters/index.ts
@@ -23,5 +23,5 @@ export const fixNoImplicitAnyParameters: FileMutator = (
 
 const isNodeNoImplicitAnyFixableParameter = (
 	node: ts.Node,
-): node is ts.ParameterDeclaration & NoImplicitAnyNodeToBeFixed =>
+): node is NoImplicitAnyNodeToBeFixed & ts.ParameterDeclaration =>
 	ts.isParameter(node) && canNodeBeFixedForNoImplicitAny(node);

--- a/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyPropertyDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoImplicitAny/fixNoImplicitAnyPropertyDeclarations/index.ts
@@ -23,5 +23,5 @@ export const fixNoImplicitAnyPropertyDeclarations: FileMutator = (
 
 const isNodeNoImplicitAnyFixablePropertyDeclaration = (
 	node: ts.Node,
-): node is ts.PropertyDeclaration & NoImplicitAnyNodeToBeFixed =>
+): node is NoImplicitAnyNodeToBeFixed & ts.PropertyDeclaration =>
 	ts.isPropertyDeclaration(node) && canNodeBeFixedForNoImplicitAny(node);

--- a/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesPropertyDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesPropertyDeclarations/index.ts
@@ -10,9 +10,9 @@ import {
 import { NodeWithType, isNodeWithType } from "../../../../shared/nodeTypes.js";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes.js";
 
-type InferablePropertyDeclaration = ts.PropertyDeclaration &
-	NodeWithType &
-	Required<Pick<ts.PropertyDeclaration, "initializer">>;
+type InferablePropertyDeclaration = NodeWithType &
+	Required<Pick<ts.PropertyDeclaration, "initializer">> &
+	ts.PropertyDeclaration;
 
 export const fixNoInferableTypesPropertyDeclarations: FileMutator = (
 	request: FileMutationsRequest,

--- a/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesVariableDeclarations/index.ts
+++ b/src/mutators/builtIn/fixNoInferableTypes/fixNoInferableTypesVariableDeclarations/index.ts
@@ -10,11 +10,11 @@ import {
 import { NodeWithType, isNodeWithType } from "../../../../shared/nodeTypes.js";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes.js";
 
-type InferableVariableDeclaration = ts.VariableDeclaration &
-	NodeWithType &
-	Required<Pick<ts.VariableDeclaration, "initializer">> & {
-		parent: ts.VariableDeclarationList;
-	};
+type InferableVariableDeclaration = {
+	parent: ts.VariableDeclarationList;
+} & NodeWithType &
+	Required<Pick<ts.VariableDeclaration, "initializer">> &
+	ts.VariableDeclaration;
 
 export const fixNoInferableTypesVariableDeclarations: FileMutator = (
 	request: FileMutationsRequest,

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -164,11 +164,11 @@ export interface TypeStatOptions extends BaseTypeStatOptions {
 /**
  * Parsed TypeScript compiler options with relevant fields filled out.
  */
-export type TypeStatCompilerOptions = ts.CompilerOptions & {
+export type TypeStatCompilerOptions = {
 	noImplicitAny: boolean;
 	noImplicitThis: boolean;
 	strictNullChecks: boolean;
-};
+} & ts.CompilerOptions;
 
 /**
  * Directives for file-level changes.

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -1,8 +1,8 @@
 import ts from "typescript";
 
-export type DiagnosticWithStart = ts.Diagnostic & {
+export type DiagnosticWithStart = {
 	start: number;
-};
+} & ts.Diagnostic;
 
 export const isDiagnosticWithStart = (
 	diagnostic: ts.Diagnostic,

--- a/src/shared/nodeExtensions.ts
+++ b/src/shared/nodeExtensions.ts
@@ -40,9 +40,9 @@ export const getBaseClassDeclaration = (
 		const { resolvedBaseConstructorType } = getTypeAtLocationIfNotError(
 			request,
 			extension.parent.parent,
-		) as ts.Type & {
+		) as {
 			resolvedBaseConstructorType: ts.Type | undefined;
-		};
+		} & ts.Type;
 
 		if (resolvedBaseConstructorType !== undefined) {
 			extensionSymbol = resolvedBaseConstructorType.symbol;

--- a/src/shared/nodeTypes.ts
+++ b/src/shared/nodeTypes.ts
@@ -11,25 +11,25 @@ export type NodeSelector<TNode extends ts.Node> = (
 /**
  * Any node type that may optionally contain a type annotation.
  */
-export type NodeWithOptionalType = ts.Node & {
+export type NodeWithOptionalType = {
 	type?: ts.TypeNode;
-};
+} & ts.Node;
 
 /**
  * Any node type that contains a type annotation.
  */
-export type NodeWithType = ts.Node & {
+export type NodeWithType = {
 	type: ts.TypeNode;
-};
+} & ts.Node;
 
-export type NodeWithIdentifierName = ts.Node & {
+export type NodeWithIdentifierName = {
 	name: ts.Identifier;
-};
+} & ts.Node;
 
-export type ParameterDeclarationWithType = ts.ParameterDeclaration &
-	NodeWithType;
+export type ParameterDeclarationWithType = NodeWithType &
+	ts.ParameterDeclaration;
 
-export type PropertySignatureWithType = ts.PropertySignature & NodeWithType;
+export type PropertySignatureWithType = NodeWithType & ts.PropertySignature;
 
 /**
  * Node types TypeStat may attempt to create a type declaration on.
@@ -42,31 +42,31 @@ export type NodeWithCreatableType =
 /**
  * Node types TypeStat may attempt to add to an existing type declaration on.
  */
-export type NodeWithAddableType = NodeWithType &
-	(
-		| ts.FunctionLikeDeclaration
-		| ts.ParameterDeclaration
-		| ts.PropertyDeclaration
-		| ts.VariableDeclaration
-	);
+export type NodeWithAddableType = (
+	| ts.FunctionLikeDeclaration
+	| ts.ParameterDeclaration
+	| ts.PropertyDeclaration
+	| ts.VariableDeclaration
+) &
+	NodeWithType;
 
 /**
  * Any function-like declaration that has an explicit type.
  */
-export type FunctionLikeDeclarationWithType = ts.FunctionLikeDeclaration &
-	NodeWithType;
+export type FunctionLikeDeclarationWithType = NodeWithType &
+	ts.FunctionLikeDeclaration;
 
 // TODO: make this a more specific type
 // Will have to deal with instantiations (new Container<T>() { ... }) and declarations (class Container<T>() { ... }))
-export type NodeWithDefinedTypeArguments = ts.Node & {
+export type NodeWithDefinedTypeArguments = {
 	typeArguments?: ts.NodeArray<ts.TypeNode>;
-};
+} & ts.Node;
 
 // TODO: make this a more specific type
 // Will have to deal with instantiations (new Container<T>() { ... }) and declarations (class Container<T>() { ... }))
-export type NodeWithTypeParameters = ts.Node & {
+export type NodeWithTypeParameters = {
 	typeParameters: ts.NodeArray<ts.TypeNode> | undefined;
-};
+} & ts.Node;
 
 export const isNodeWithType = (
 	node: NodeWithOptionalType,
@@ -90,8 +90,8 @@ export const isNodeWithTypeParameters = (
 	return "typeParameters" in node;
 };
 
-export type PropertySignatureWithStaticName = ts.PropertySignature &
-	NodeWithIdentifierName;
+export type PropertySignatureWithStaticName = NodeWithIdentifierName &
+	ts.PropertySignature;
 
 export const isPropertySignatureWithStaticName = (
 	node: ts.Node,

--- a/src/shared/typeNodes.ts
+++ b/src/shared/typeNodes.ts
@@ -17,9 +17,9 @@ export type WellKnownTypeName =
 	| "unknown"
 	| "void";
 
-export type TypeWithTypeArguments = ts.Type & {
+export type TypeWithTypeArguments = {
 	typeArguments: ts.Type[];
-};
+} & ts.Type;
 
 export const isTypeArgumentsType = (
 	type: ts.Type,
@@ -27,9 +27,9 @@ export const isTypeArgumentsType = (
 	return "typeArguments" in type && !!type.typeArguments;
 };
 
-export type TypeWithOptionalTypeArguments = ts.Type & {
+export type TypeWithOptionalTypeArguments = {
 	typeArguments?: ts.Type[];
-};
+} & ts.Type;
 
 export const isOptionalTypeArgumentsTypeNode = (
 	type: ts.Type,
@@ -37,9 +37,9 @@ export const isOptionalTypeArgumentsTypeNode = (
 	return "typeArguments" in type;
 };
 
-export type TypeWithIntrinsicName = ts.Type & {
+export type TypeWithIntrinsicName = {
 	intrinsicName: WellKnownTypeName;
-};
+} & ts.Type;
 
 export const isIntrinsicNameType = (
 	type: ts.Type,


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Supersedes https://github.com/JoshuaKGoldberg/TypeStat/pull/1582. This includes the lint fixes.

I'm not sure I think most of change are improvements here. It would more sense to keep existing way for some of them. So maybe it would be better to turn `perfectionist/sort-intersection-types` rule off for now? 🤔  I think it sort named types first and then add `{}` part. (Also see https://github.com/azat-io/eslint-plugin-perfectionist/issues/143 and https://github.com/azat-io/eslint-plugin-perfectionist/issues/128 - so there may be new config options later)

For example: `NodeWithIdentifierName`

It was:
```ts
export type NodeWithIdentifierName = ts.Node & {
	name: ts.Identifier;
};
```

And now it is:
```ts
export type NodeWithIdentifierName = {
	name: ts.Identifier;
} & ts.Node;
``` 

But that aside, this PR fixes the lint errors so we can update the eslint plugin :) 