### PR TITLE
fix: reduce work in loop

### DIFF
--- a/src/mutations/collecting.ts
+++ b/src/mutations/collecting.ts
@@ -137,9 +137,7 @@ const findMissingTypes = (
 		// The 'void' type shouldn't be assigned to anything, so we ignore it
 		if (assignedType.flags === ts.TypeFlags.Void) {
 			remainingMissingTypes.delete(assignedType);
-		}
-
-		if (!isAssignedTypeMissingFromDeclared(assignedType)) {
+		} else if (!isAssignedTypeMissingFromDeclared(assignedType)) {
 			remainingMissingTypes.delete(assignedType);
 		}
 	}


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [X] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Make the case for the void type
mutually exclusive with the other
check in the loop.

Suggested in https://github.com/JoshuaKGoldberg/TypeStat/pull/2025#discussion_r1864332874.