### PR TITLE
chore: fix eslint-plugin-markdown 5 update

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -55,7 +55,7 @@ module.exports = {
 		{
 			files: "**/*.md/*.ts",
 			rules: {
-				"n/no-missing-import": ["error", { allowModules: ["TypeStat"] }],
+				"n/no-missing-import": ["error", { allowModules: ["typestat"] }],
 			},
 		},
 		{

--- a/docs/Custom Mutators.md
+++ b/docs/Custom Mutators.md
@@ -24,6 +24,8 @@ It should return an array of Automutate `Mutation` objects.
 
 For example, if you run `typestat --add ./src/mutators/myMutator`, there should exist a `./src/mutators/myMutator.js` file _(or `./src/mutators/myMutator/index.js`)_:
 
+<!-- eslint-disable @typescript-eslint/no-unused-vars -->
+
 ```typescript
 import { Mutation } from "automutate";
 import { FileMutationsRequest } from "typestat";

--- a/docs/Package.md
+++ b/docs/Package.md
@@ -56,6 +56,10 @@ that package will be installed.
 
 For example, if the following code exists in any file within the TypeScript project:
 
+<!-- eslint-disable @typescript-eslint/no-unused-vars -->
+<!-- eslint-disable no-unused-vars -->
+<!-- eslint-disable n/no-missing-import -->
+
 ```javascript
 import { array } from "lodash/array";
 ```

--- a/docs/Package.md
+++ b/docs/Package.md
@@ -56,9 +56,7 @@ that package will be installed.
 
 For example, if the following code exists in any file within the TypeScript project:
 
-<!-- eslint-disable @typescript-eslint/no-unused-vars -->
-<!-- eslint-disable no-unused-vars -->
-<!-- eslint-disable n/no-missing-import -->
+<!-- eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars, n/no-missing-import -->
 
 ```javascript
 import { array } from "lodash/array";

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"eslint-plugin-eslint-comments": "^3.2.0",
 		"eslint-plugin-jsdoc": "^50.0.0",
 		"eslint-plugin-jsonc": "^2.14.1",
-		"eslint-plugin-markdown": "^4.0.1",
+		"eslint-plugin-markdown": "^5.0.0",
 		"eslint-plugin-n": "^17.0.0",
 		"eslint-plugin-package-json": "^0.15.0",
 		"eslint-plugin-perfectionist": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^2.14.1
         version: 2.18.2(eslint@8.57.1)
       eslint-plugin-markdown:
-        specifier: ^4.0.1
-        version: 4.0.1(eslint@8.57.1)
+        specifier: ^5.0.0
+        version: 5.1.0(eslint@8.57.1)
       eslint-plugin-n:
         specifier: ^17.0.0
         version: 17.14.0(eslint@8.57.1)
@@ -1814,8 +1814,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-plugin-markdown@4.0.1:
-    resolution: {integrity: sha512-5/MnGvYU0i8MbHH5cg8S+Vl3DL+bqRNYshk1xUO86DilNBaxtTkhH+5FD0/yO03AmlI6+lfNFdk2yOw72EPzpA==}
+  eslint-plugin-markdown@5.1.0:
+    resolution: {integrity: sha512-SJeyKko1K6GwI0AN6xeCDToXDkfKZfXcexA6B+O2Wr2btUS9GrC+YgwSyVli5DJnctUHjFXcQ2cqTaAmVoLi2A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8'
@@ -5280,7 +5280,7 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-markdown@4.0.1(eslint@8.57.1):
+  eslint-plugin-markdown@5.1.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       mdast-util-from-markdown: 0.8.5


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fix the casing of TypeStat in eslintrc, and add some ESLint suppressions for the blocks that trigger lint errors. This makes the new version of the plugin pass on the documentation.