### PR TITLE
chore: remove unused disable-directive from linting after building

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -51,6 +51,8 @@ ESLint can be run with `--fix` to auto-fix some lint rule complaints:
 pnpm run lint --fix
 ```
 
+Note that you'll likely need to run `pnpm build` before `pnpm lint` so that lint rules which check the file system can pick up on any built files.
+
 ## Testing
 
 There are two kinds of tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
+      - run: pnpm build
       - run: pnpm lint
 
 name: Lint

--- a/bin/typestat.mjs
+++ b/bin/typestat.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-// eslint-disable-next-line n/no-missing-import
 import { runCli } from "../lib/cli/runCli.js";
 
 runCli(process.argv)


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2304
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This is also noted in: https://github.com/JoshuaKGoldberg/create-typescript-app/blob/e65eae3e00d797ce0d88b5a1eb9707c857c66944/.github/DEVELOPMENT.md?plain=1#L61

💖 