### PR TITLE
fix: writing TypeScript config file

### DIFF
--- a/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.test.ts
+++ b/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.test.ts
@@ -34,13 +34,13 @@ describe("writeMultiTypeScriptConfig", () => {
 				},
 			},
 			{
-				exclude: ["test/**/*.{ts,tsx}"],
 				fixes: {
 					incompleteTypes: true,
 					noImplicitAny: true,
 					noImplicitThis: true,
 					noInferableTypes: true,
 				},
+				include: undefined,
 				projectPath: "./tsconfig.json",
 			},
 			{

--- a/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.test.ts
+++ b/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { InitializationImprovement } from "./improvements.js";
+import { generateMultiTypeScriptConfig } from "./writeMultiTypeScriptConfig.js";
+
+describe("writeMultiTypeScriptConfig", () => {
+	it("creates multi TypeScript config", () => {
+		const config = generateMultiTypeScriptConfig({
+			fileName: "typestat.json",
+			improvements: new Set([
+				InitializationImprovement.MissingProperties,
+				InitializationImprovement.NoImplicitAny,
+				InitializationImprovement.NoImplicitThis,
+				InitializationImprovement.NoInferableTypes,
+				InitializationImprovement.StrictNullChecks,
+			]),
+			project: { filePath: "./tsconfig.json" },
+			testFiles: "test/**/*.{ts,tsx}",
+		});
+
+		expect(config).toStrictEqual([
+			{
+				fixes: {
+					incompleteTypes: true,
+					noImplicitAny: true,
+					noImplicitThis: true,
+					noInferableTypes: true,
+					strictNonNullAssertions: true,
+				},
+				include: ["test/**/*.{ts,tsx}"],
+				projectPath: "./tsconfig.json",
+				types: {
+					strictNullChecks: true,
+				},
+			},
+			{
+				exclude: ["test/**/*.{ts,tsx}"],
+				fixes: {
+					incompleteTypes: true,
+					noImplicitAny: true,
+					noImplicitThis: true,
+					noInferableTypes: true,
+				},
+				projectPath: "./tsconfig.json",
+			},
+			{
+				fixes: {
+					incompleteTypes: true,
+					noImplicitAny: true,
+					noImplicitThis: true,
+					noInferableTypes: true,
+				},
+				include: ["test/**/*.{ts,tsx}"],
+				projectPath: "./tsconfig.json",
+			},
+		]);
+	});
+});

--- a/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
+++ b/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 
 import { Fixes, RawTypeStatOptions } from "../../options/types.js";
+import { isNotUndefined } from "../../shared/arrays.js";
 import { ProjectDescription } from "../initializeProject/shared.js";
 import { InitializationImprovement } from "./improvements.js";
 
@@ -32,6 +33,7 @@ export const generateMultiTypeScriptConfig = ({
 			...fixes,
 			strictNonNullAssertions: true,
 		},
+		include: testFiles ? [testFiles] : undefined,
 		projectPath: project.filePath,
 		types: {
 			strictNullChecks: true,
@@ -40,30 +42,17 @@ export const generateMultiTypeScriptConfig = ({
 
 	const stage2: Partial<RawTypeStatOptions> = {
 		fixes,
+		include: sourceFiles ? [sourceFiles] : undefined,
 		projectPath: project.filePath,
 	};
+
+	const stage3Include = [testFiles, sourceFiles].filter(isNotUndefined);
 
 	const stage3: Partial<RawTypeStatOptions> = {
 		fixes,
+		include: stage3Include.length ? stage3Include : undefined,
 		projectPath: project.filePath,
 	};
-
-	if (testFiles) {
-		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
-		stage1.include = [testFiles];
-		// @ts-expect-error Property 'exclude' does not exist on type 'Partial<PendingTypeStatOptions>'.
-		stage2.exclude = [testFiles];
-		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
-		stage3.include = [testFiles, sourceFiles].filter(Boolean);
-	} else {
-		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
-		stage3.include = [sourceFiles].filter(Boolean);
-	}
-
-	if (sourceFiles) {
-		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
-		stage2.include = [sourceFiles];
-	}
 
 	return [stage1, stage2, stage3];
 };

--- a/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
+++ b/src/initialization/initializeTypeScript/writeMultiTypeScriptConfig.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 
+import { Fixes, RawTypeStatOptions } from "../../options/types.js";
 import { ProjectDescription } from "../initializeProject/shared.js";
 import { InitializationImprovement } from "./improvements.js";
 
@@ -11,61 +12,74 @@ export interface MultiTypeScriptConfigSettings {
 	testFiles?: string;
 }
 
-export const writeMultiTypeScriptConfig = async ({
-	fileName,
+export const writeMultiTypeScriptConfig = async (
+	settings: MultiTypeScriptConfigSettings,
+) => {
+	const config = generateMultiTypeScriptConfig(settings);
+	await fs.writeFile(settings.fileName, JSON.stringify(config, undefined, 4));
+};
+
+export const generateMultiTypeScriptConfig = ({
 	improvements,
 	project,
 	sourceFiles,
 	testFiles,
 }: MultiTypeScriptConfigSettings) => {
-	await fs.writeFile(
-		fileName,
-		JSON.stringify(
-			[
-				{
-					fixes: {
-						...printImprovements(improvements),
-						strictNonNullAssertions: true,
-					},
-					...(testFiles && { include: [testFiles] }),
-					projectPath: project.filePath,
-					types: {
-						strictNullChecks: true,
-					},
-				},
-				{
-					...(testFiles && { exclude: [testFiles] }),
-					fixes: printImprovements(improvements),
-					...(sourceFiles && { include: [sourceFiles] }),
-					projectPath: project.filePath,
-				},
-				{
-					fixes: printImprovements(improvements),
-					...(testFiles
-						? { include: [testFiles, sourceFiles] }
-						: { include: [sourceFiles] }),
-					projectPath: project.filePath,
-				},
-			],
-			undefined,
-			4,
-		),
-	);
+	const fixes = printImprovements(improvements);
+
+	const stage1: Partial<RawTypeStatOptions> = {
+		fixes: {
+			...fixes,
+			strictNonNullAssertions: true,
+		},
+		projectPath: project.filePath,
+		types: {
+			strictNullChecks: true,
+		},
+	};
+
+	const stage2: Partial<RawTypeStatOptions> = {
+		fixes,
+		projectPath: project.filePath,
+	};
+
+	const stage3: Partial<RawTypeStatOptions> = {
+		fixes,
+		projectPath: project.filePath,
+	};
+
+	if (testFiles) {
+		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
+		stage1.include = [testFiles];
+		// @ts-expect-error Property 'exclude' does not exist on type 'Partial<PendingTypeStatOptions>'.
+		stage2.exclude = [testFiles];
+		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
+		stage3.include = [testFiles, sourceFiles].filter(Boolean);
+	} else {
+		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
+		stage3.include = [sourceFiles].filter(Boolean);
+	}
+
+	if (sourceFiles) {
+		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
+		stage2.include = [sourceFiles];
+	}
+
+	return [stage1, stage2, stage3];
 };
 
 const printImprovements = (
 	improvements: ReadonlySet<InitializationImprovement>,
-) => {
-	return {
-		incompleteTypes: true,
-		...(improvements.has(InitializationImprovement.NoImplicitAny) && {
-			noImplicitAny: true,
-		}),
-		...(improvements.has(InitializationImprovement.NoInferableTypes) && {
-			inferableTypes: true,
-		}),
-		...(improvements.has(InitializationImprovement.NoImplicitThis) && {
-			noImplicitThis: true,
-		}),
-	};
+): Partial<Fixes> => {
+	const fixes: Partial<Fixes> = { incompleteTypes: true };
+	if (improvements.has(InitializationImprovement.NoImplicitAny)) {
+		fixes.noImplicitAny = true;
+	}
+	if (improvements.has(InitializationImprovement.NoInferableTypes)) {
+		fixes.noInferableTypes = true;
+	}
+	if (improvements.has(InitializationImprovement.NoImplicitThis)) {
+		fixes.noImplicitThis = true;
+	}
+	return fixes;
 };

--- a/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.test.ts
+++ b/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.test.ts
@@ -16,7 +16,12 @@ describe("writeMultiTypeScriptConfig", () => {
 				incompleteTypes: true,
 				noImplicitAny: true,
 			},
+			include: undefined,
 			projectPath: "./tsconfig.json",
 		});
+
+		expect(JSON.stringify(config)).toBe(
+			'{"fixes":{"incompleteTypes":true,"noImplicitAny":true},"projectPath":"./tsconfig.json"}',
+		);
 	});
 });

--- a/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.test.ts
+++ b/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { InitializationImprovement } from "./improvements.js";
+import { generateSingleTypeScriptConfig } from "./writeSingleTypeScriptConfig.js";
+
+describe("writeMultiTypeScriptConfig", () => {
+	it("creates multi TypeScript config", () => {
+		const config = generateSingleTypeScriptConfig({
+			fileName: "typestat.json",
+			improvements: new Set([InitializationImprovement.NoImplicitAny]),
+			project: { filePath: "./tsconfig.json" },
+		});
+
+		expect(config).toStrictEqual({
+			fixes: {
+				incompleteTypes: true,
+				noImplicitAny: true,
+			},
+			projectPath: "./tsconfig.json",
+		});
+	});
+});

--- a/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.ts
+++ b/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.ts
@@ -25,13 +25,9 @@ export const generateSingleTypeScriptConfig = ({
 }: SingleTypeScriptConfigSettings) => {
 	const config: Partial<RawTypeStatOptions> = {
 		fixes: printImprovements(improvements),
+		include: sourceFiles ? [sourceFiles] : undefined,
 		projectPath: project.filePath,
 	};
-
-	if (sourceFiles) {
-		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
-		config.include = [sourceFiles];
-	}
 	return config;
 };
 

--- a/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.ts
+++ b/src/initialization/initializeTypeScript/writeSingleTypeScriptConfig.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 
+import { Fixes, RawTypeStatOptions } from "../../options/types.js";
 import { ProjectDescription } from "../initializeProject/shared.js";
 import { InitializationImprovement } from "./improvements.js";
 
@@ -10,36 +11,39 @@ export interface SingleTypeScriptConfigSettings {
 	sourceFiles?: string;
 }
 
-export const writeSingleTypeScriptConfig = async ({
-	fileName,
+export const writeSingleTypeScriptConfig = async (
+	settings: SingleTypeScriptConfigSettings,
+) => {
+	const config = generateSingleTypeScriptConfig(settings);
+	await fs.writeFile(settings.fileName, JSON.stringify(config, undefined, 4));
+};
+
+export const generateSingleTypeScriptConfig = ({
 	improvements,
 	project,
 	sourceFiles,
 }: SingleTypeScriptConfigSettings) => {
-	await fs.writeFile(
-		fileName,
-		JSON.stringify(
-			{
-				fixes: printImprovements(improvements),
-				...(sourceFiles && { include: [sourceFiles] }),
-				projectPath: project.filePath,
-			},
-			undefined,
-			4,
-		),
-	);
+	const config: Partial<RawTypeStatOptions> = {
+		fixes: printImprovements(improvements),
+		projectPath: project.filePath,
+	};
+
+	if (sourceFiles) {
+		// @ts-expect-error Cannot assign to 'include' because it is a read-only property.
+		config.include = [sourceFiles];
+	}
+	return config;
 };
 
 const printImprovements = (
 	improvements: ReadonlySet<InitializationImprovement>,
-) => {
-	return {
-		incompleteTypes: true,
-		...(improvements.has(InitializationImprovement.NoImplicitAny) && {
-			noImplicitAny: true,
-		}),
-		...(improvements.has(InitializationImprovement.NoImplicitThis) && {
-			noImplicitThis: true,
-		}),
-	};
+): Partial<Fixes> => {
+	const fixes: Partial<Fixes> = { incompleteTypes: true };
+	if (improvements.has(InitializationImprovement.NoImplicitAny)) {
+		fixes.noImplicitAny = true;
+	}
+	if (improvements.has(InitializationImprovement.NoImplicitThis)) {
+		fixes.noImplicitThis = true;
+	}
+	return fixes;
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2113
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- Fixes issue where `null` was inserted to typestat.json `includes` list
- Fixes issue where option was `inferableTypes` when it should be `noInferableTypes`
- Added basic testing for config generation

For future:
- Config generation is still little bit broken. If I want to select just "Remove type annotations that don't change the meaning of code" option, the generated config file does not have it but instead has just `"incompleteTypes": true`.  -> Needs new issue created. 

🐙 