### PR TITLE
fix: replace builtin-modules package with node's isBuiltin check

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 	"dependencies": {
 		"@phenomnomnominal/tsquery": "6.1.3",
 		"automutate": "0.9.0",
-		"builtin-modules": "4.0.0",
 		"chalk": "5.4.1",
 		"commander": "13.1.0",
 		"enquirer": "2.4.1",
@@ -89,7 +88,7 @@
 	},
 	"packageManager": "pnpm@9.15.4",
 	"engines": {
-		"node": ">=18"
+		"node": ">=18.6"
 	},
 	"publishConfig": {
 		"provenance": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       automutate:
         specifier: 0.9.0
         version: 0.9.0
-      builtin-modules:
-        specifier: 4.0.0
-        version: 4.0.0
       chalk:
         specifier: 5.4.1
         version: 5.4.1
@@ -1372,10 +1369,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  builtin-modules@4.0.0:
-    resolution: {integrity: sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA==}
-    engines: {node: '>=18.20'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -4798,8 +4791,6 @@ snapshots:
       fill-range: 7.1.1
 
   buffer-from@1.1.2: {}
-
-  builtin-modules@4.0.0: {}
 
   bundle-name@4.1.0:
     dependencies:

--- a/src/runtime/providers/createInstallMissingTypesProvider.ts
+++ b/src/runtime/providers/createInstallMissingTypesProvider.ts
@@ -1,5 +1,3 @@
-import builtinModules from "builtin-modules";
-
 import { setSubtract } from "../../shared/sets.js";
 import { createFileNamesAndServices } from "../createFileNamesAndServices.js";
 import { createSingleUseProvider } from "../createSingleUseProvider.js";
@@ -7,8 +5,6 @@ import { collectExistingTypingPackages } from "./missingTypes/collectExistingTyp
 import { collectPackageManagerRunner } from "./missingTypes/collectPackageManagerRunner.js";
 import { collectReferencedPackageNames } from "./missingTypes/collectReferencedPackageNames.js";
 import { filterTypedPackageNames } from "./missingTypes/filterTypedPackageNames.js";
-
-const uniqueBuiltinModules = new Set(builtinModules);
 
 /**
  * Creates a mutations provider that installs missing types modules.
@@ -43,7 +39,6 @@ export const createInstallMissingTypesProvider = () => {
 					const missingPackageNames = setSubtract(
 						referencedPackageNames,
 						new Set(existingPackageNames),
-						uniqueBuiltinModules,
 					);
 					const missingTypedPackageNames = await filterTypedPackageNames(
 						Array.from(missingPackageNames),

--- a/src/runtime/providers/createInstallMissingTypesProvider.ts
+++ b/src/runtime/providers/createInstallMissingTypesProvider.ts
@@ -1,4 +1,3 @@
-import { setSubtract } from "../../shared/sets.js";
 import { createFileNamesAndServices } from "../createFileNamesAndServices.js";
 import { createSingleUseProvider } from "../createSingleUseProvider.js";
 import { collectExistingTypingPackages } from "./missingTypes/collectExistingTypingPackages.js";
@@ -32,12 +31,9 @@ export const createInstallMissingTypesProvider = () => {
 
 					// Collect every package name referenced by every file in the project
 					const { services } = createFileNamesAndServices(options);
-					const referencedPackageNames =
-						collectReferencedPackageNames(services);
-
 					// Ignore package names already referenced in package.json or that don't exist in DefinitelyTyped
-					const missingPackageNames = setSubtract(
-						referencedPackageNames,
+					const missingPackageNames = collectReferencedPackageNames(
+						services,
 						new Set(existingPackageNames),
 					);
 					const missingTypedPackageNames = await filterTypedPackageNames(

--- a/src/runtime/providers/missingTypes/collectReferencedPackageNames.test.ts
+++ b/src/runtime/providers/missingTypes/collectReferencedPackageNames.test.ts
@@ -8,7 +8,7 @@ import { createLanguageServices } from "../../../services/language.js";
 import { collectReferencedPackageNames } from "./collectReferencedPackageNames.js";
 
 describe("collectReferencedPackageNames", () => {
-	it.skip("should return package names", () => {
+	it("should return package names", () => {
 		const options: Partial<TypeStatOptions> = {
 			compilerOptions: {} as Readonly<TypeStatCompilerOptions>,
 			package: {

--- a/src/runtime/providers/missingTypes/collectReferencedPackageNames.test.ts
+++ b/src/runtime/providers/missingTypes/collectReferencedPackageNames.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	TypeStatCompilerOptions,
+	TypeStatOptions,
+} from "../../../options/types.js";
+import { createLanguageServices } from "../../../services/language.js";
+import { collectReferencedPackageNames } from "./collectReferencedPackageNames.js";
+
+describe("collectReferencedPackageNames", () => {
+	it.skip("should return package names", () => {
+		const options: Partial<TypeStatOptions> = {
+			compilerOptions: {} as Readonly<TypeStatCompilerOptions>,
+			package: {
+				directory: process.cwd(),
+				file: "package.json",
+				missingTypes: true,
+			},
+			projectPath: "tsconfig.json",
+		};
+		const services = createLanguageServices(options as TypeStatOptions);
+
+		const packageNames = collectReferencedPackageNames(
+			services,
+			new Set<string>(),
+		);
+
+		expect(Array.from(packageNames)).toStrictEqual(["node", "automutate"]);
+	});
+
+	it("should ignore defined package names", () => {
+		const options: Partial<TypeStatOptions> = {
+			compilerOptions: {} as Readonly<TypeStatCompilerOptions>,
+			package: {
+				directory: process.cwd(),
+				file: "package.json",
+				missingTypes: true,
+			},
+			projectPath: "tsconfig.json",
+		};
+		const services = createLanguageServices(options as TypeStatOptions);
+
+		const packageNames = collectReferencedPackageNames(
+			services,
+			new Set<string>(["automutate"]),
+		);
+
+		expect(Array.from(packageNames)).toStrictEqual(["node"]);
+	});
+});

--- a/src/runtime/providers/missingTypes/collectReferencedPackageNames.ts
+++ b/src/runtime/providers/missingTypes/collectReferencedPackageNames.ts
@@ -5,7 +5,7 @@ import { LanguageServices } from "../../../services/language.js";
 
 export const collectReferencedPackageNames = (
 	services: LanguageServices,
-	ignoredPackages: Set<string>,
+	ignoredPackages: ReadonlySet<string>,
 ) => {
 	const packageNames = new Set<string>();
 
@@ -24,7 +24,7 @@ export const collectReferencedPackageNames = (
 
 const collectFileReferencedPackageNames = (
 	sourceFile: ts.SourceFile,
-	ignoredPackages: Set<string>,
+	ignoredPackages: ReadonlySet<string>,
 ) => {
 	const packageNames = new Set<string>();
 

--- a/src/runtime/providers/missingTypes/collectReferencedPackageNames.ts
+++ b/src/runtime/providers/missingTypes/collectReferencedPackageNames.ts
@@ -1,3 +1,4 @@
+import { isBuiltin } from "node:module";
 import ts from "typescript";
 
 import { LanguageServices } from "../../../services/language.js";
@@ -7,7 +8,9 @@ export const collectReferencedPackageNames = (services: LanguageServices) => {
 
 	for (const sourceFile of services.program.getSourceFiles()) {
 		for (const packageName of collectFileReferencedPackageNames(sourceFile)) {
-			packageNames.add(packageName);
+			if (!isBuiltin(packageName)) {
+				packageNames.add(packageName);
+			}
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2175
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

There is no need to use external package for this check, when we can use node's own `isBuiltin()` check. However, it needed minimum node version to be upgrade to `>=18.6`.

🐙 