### PR TITLE
fix: replace `strip-ansi` with `stripVTControlCharacters`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"commander": "13.1.0",
 		"enquirer": "2.4.1",
 		"glob": "11.0.1",
-		"strip-ansi": "7.1.0",
 		"ts-api-utils": "2.0.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       glob:
         specifier: 11.0.1
         version: 11.0.1
-      strip-ansi:
-        specifier: 7.1.0
-        version: 7.1.0
       ts-api-utils:
         specifier: 2.0.0
         version: 2.0.0(typescript@5.7.3)

--- a/src/output/createProcessOutput.ts
+++ b/src/output/createProcessOutput.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { EOL } from "os";
-import stripAnsi from "strip-ansi";
+import { stripVTControlCharacters } from "util";
 
 import { ProcessOutput } from "./types.js";
 
@@ -11,7 +11,7 @@ export const createProcessOutput = (logFile?: string): ProcessOutput => {
 		return (line: string) => {
 			stream.write(line + EOL);
 			log?.(
-				stripAnsi(
+				stripVTControlCharacters(
 					`[${prefix}] ${line.replace(/^\r\n|\r|\n/g, "").replace(/\r\n|\r|\n$/g, "")}`,
 				),
 			);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2177
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`stripVTControlCharacters` was added in nodejs v16.11.0 and appears to be a direct replacement for the functionality from `strip-ansi`.

`TypeStat` already declares a dependency on nodejs >= 18 in its `package.json`, so depending on this new API should be safe.

Fixes #2177