### PR TITLE
fix: simplify collecting strict TS options

### DIFF
--- a/src/options/fillOutRawOptions.ts
+++ b/src/options/fillOutRawOptions.ts
@@ -30,7 +30,6 @@ export const fillOutRawOptions = ({
 	projectPath,
 	rawOptions,
 }: OptionsFromRawOptionsSettings): PendingTypeStatOptions => {
-	const rawOptionTypes = rawOptions.types ?? {};
 	const noImplicitAny = collectNoImplicitAny(
 		parsedTsConfig.options,
 		rawOptions,
@@ -39,8 +38,10 @@ export const fillOutRawOptions = ({
 		parsedTsConfig.options,
 		rawOptions,
 	);
-	const { compilerStrictNullChecks, typeStrictNullChecks } =
-		collectStrictNullChecks(parsedTsConfig.options, rawOptionTypes);
+	const strictNullChecks = collectStrictNullChecks(
+		parsedTsConfig.options,
+		rawOptions,
+	);
 
 	const packageOptions = collectPackageOptions(cwd, rawOptions);
 
@@ -92,13 +93,13 @@ export const fillOutRawOptions = ({
 				noEmit: true,
 				noImplicitAny,
 				noImplicitThis,
-				strictNullChecks: compilerStrictNullChecks,
+				strictNullChecks,
 			},
 		},
 		postProcess: { shell },
 		projectPath,
 		types: {
-			strictNullChecks: typeStrictNullChecks,
+			strictNullChecks: strictNullChecks || undefined,
 		},
 	};
 };

--- a/src/options/parsing/collectNoImplicitAny.ts
+++ b/src/options/parsing/collectNoImplicitAny.ts
@@ -5,14 +5,8 @@ import { RawTypeStatOptions } from "../types.js";
 export const collectNoImplicitAny = (
 	compilerOptions: Readonly<ts.CompilerOptions>,
 	rawOptions: RawTypeStatOptions,
-): boolean => {
-	if (rawOptions.fixes?.noImplicitAny !== undefined) {
-		return rawOptions.fixes.noImplicitAny;
-	}
-
-	if (compilerOptions.noImplicitAny !== undefined) {
-		return compilerOptions.noImplicitAny;
-	}
-
-	return false;
-};
+): boolean =>
+	rawOptions.fixes?.noImplicitAny ||
+	compilerOptions.noImplicitAny ||
+	compilerOptions.strict ||
+	false;

--- a/src/options/parsing/collectNoImplicitThis.ts
+++ b/src/options/parsing/collectNoImplicitThis.ts
@@ -5,14 +5,8 @@ import { RawTypeStatOptions } from "../types.js";
 export const collectNoImplicitThis = (
 	compilerOptions: Readonly<ts.CompilerOptions>,
 	rawOptions: RawTypeStatOptions,
-): boolean => {
-	if (rawOptions.fixes?.noImplicitThis !== undefined) {
-		return rawOptions.fixes.noImplicitThis;
-	}
-
-	if (compilerOptions.noImplicitThis !== undefined) {
-		return compilerOptions.noImplicitThis;
-	}
-
-	return false;
-};
+): boolean =>
+	rawOptions.fixes?.noImplicitThis ||
+	compilerOptions.noImplicitThis ||
+	compilerOptions.strict ||
+	false;

--- a/src/options/parsing/collectStrictNullChecks.ts
+++ b/src/options/parsing/collectStrictNullChecks.ts
@@ -1,35 +1,13 @@
 import ts from "typescript";
 
-import { RawTypeStatTypeOptions } from "../types.js";
+import { RawTypeStatOptions } from "../types.js";
 
+/** If strictNullChecks enabled either in typestat config or in tsconfig. */
 export const collectStrictNullChecks = (
 	compilerOptions: Readonly<ts.CompilerOptions>,
-	rawOptionTypes: RawTypeStatTypeOptions,
-) => {
-	const typeStrictNullChecks = rawOptionTypes.strictNullChecks;
-	const compilerStrictNullChecks = collectCompilerStrictNullChecks(
-		compilerOptions,
-		typeStrictNullChecks,
-	);
-
-	return { compilerStrictNullChecks, typeStrictNullChecks };
-};
-
-const collectCompilerStrictNullChecks = (
-	compilerOptions: Readonly<ts.CompilerOptions>,
-	typeStrictNullChecks: boolean | undefined,
-): boolean => {
-	if (typeStrictNullChecks !== undefined) {
-		return typeStrictNullChecks;
-	}
-
-	if (compilerOptions.strictNullChecks !== undefined) {
-		return compilerOptions.strictNullChecks;
-	}
-
-	if (compilerOptions.strict !== undefined) {
-		return compilerOptions.strict;
-	}
-
-	return false;
-};
+	rawOptions: RawTypeStatOptions,
+): boolean =>
+	rawOptions.types?.strictNullChecks ||
+	compilerOptions.strictNullChecks ||
+	compilerOptions.strict ||
+	false;

--- a/test/__snapshots__/cleanups.test.ts.snap
+++ b/test/__snapshots__/cleanups.test.ts.snap
@@ -101,7 +101,9 @@ exports[`Cleanups > non-TypeErrors > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": true
+    }
   }
 ]"
 `;
@@ -203,7 +205,9 @@ exports[`Cleanups > suppressTypeErrors > options 1`] = `
       "shell": []
     },
     "projectPath": "<rootDir>/tsconfig.json",
-    "types": {}
+    "types": {
+      "strictNullChecks": true
+    }
   }
 ]"
 `;


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I forgot this from #2192 , though maybe it's better to have it separately. 

This simplifies and IMO corrects the logic for some of these options. Before, it was possible that if you have `noImplicitAny` set as false in `typestat.json` file for the fixes, it would change the typescript compiler options to be also false. This could lead to weird behavior.

New logic set  `noImplicitAny`  as true in the collected compiler options if it's true either in the fixes section or in the original ts config file.

I think the `types` section in `BaseTypeStatOptions` is unnecessary. It's only used in `findComplaintForOptions` to check options and print "fixes.strictNonNullAssertions specified but not strictNullChecks." if there is mismatch. That check could use the actual collected compiler options.  However, it's not harmful to keep it.
