### PR TITLE
fix: incompleteReturnTypes: async function can only return Promises

### DIFF
--- a/src/mutations/collecting.ts
+++ b/src/mutations/collecting.ts
@@ -6,6 +6,11 @@ import { isKnownGlobalBaseType } from "../shared/nodeTypes.js";
 import { setSubtract } from "../shared/sets.js";
 import { isTypeFlagSetRecursively } from "./collecting/flags.js";
 
+interface MissingTypesResult {
+	assignedTypes: Set<ts.Type>;
+	missingTypes: ReadonlySet<ts.Type>;
+}
+
 /**
  * Collects assigned and missing types, recursively accounting for type unions.
  * @param request Metadata and settings to collect mutations in a file.
@@ -16,7 +21,7 @@ export const collectUsageSymbols = (
 	request: FileMutationsRequest,
 	declaredType: ts.Type,
 	allAssignedTypes: readonly ts.Type[],
-) => {
+): MissingTypesResult => {
 	// Collect which types are later assigned to the type
 	const assignedTypes = collectRawTypesFromTypes(request, allAssignedTypes);
 
@@ -89,7 +94,7 @@ export const recursivelyCollectSubTypes = (type: ts.UnionType): ts.Type[] => {
 	return subTypes;
 };
 
-const findMissingTypes = (
+export const findMissingTypes = (
 	request: FileMutationsRequest,
 	assignedTypes: ReadonlySet<ts.Type>,
 	declaredTypes: ReadonlySet<ts.Type>,

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -57,43 +57,8 @@ export const createTypeAdditionMutation = (
 		return textSwap(` ${newTypeAlias}`, node.type.pos, node.type.end);
 	}
 
-	const isAsyncFunction =
-		ts.isFunctionDeclaration(node) &&
-		node.modifiers?.some((modifier) => tsutils.isAsyncKeyword(modifier));
-
-	if (!isAsyncFunction) {
-		// Create a mutation insertion that adds the missing types in
-		return textInsert(` | ${newTypeAlias}`, node.type.end);
-	}
-
-	const typeChecker = request.services.languageService
-		.getProgram()
-		?.getTypeChecker();
-
-	const typesAsPromises = new Set(
-		[...missingTypes].map((type) => {
-			const stringified = typeChecker?.typeToString(
-				typeChecker.getBaseTypeOfLiteralType(type),
-			);
-			return stringified?.startsWith("Promise<")
-				? stringified
-				: `Promise<${stringified}>`;
-		}),
-	);
-
-	const combined = [...typesAsPromises]
-		.sort((a, b) => a.localeCompare(b))
-		.join(" | ");
-
-	const declaredTypeAsString = typeChecker?.typeToString(declaredType);
-
-	// After adding Promise wrappers, it may be that the type is same as the original
-	if (combined === declaredTypeAsString) {
-		return undefined;
-	}
-
 	// Create a mutation insertion that adds the missing types in
-	return textInsert(` | ${combined}`, node.type.end);
+	return textInsert(` | ${newTypeAlias}`, node.type.end);
 };
 
 /**

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -76,7 +76,9 @@ export const createTypeAdditionMutation = (
 			const stringified = typeChecker?.typeToString(
 				typeChecker.getBaseTypeOfLiteralType(type),
 			);
-			return `Promise<${stringified}>`;
+			return stringified?.startsWith("Promise<")
+				? stringified
+				: `Promise<${stringified}>`;
 		}),
 	);
 

--- a/src/mutations/text-mutations.ts
+++ b/src/mutations/text-mutations.ts
@@ -1,0 +1,29 @@
+import { TextInsertMutation, TextSwapMutation } from "automutate";
+
+export const textInsert = (
+	insertion: string,
+	begin: number,
+): TextInsertMutation => {
+	return {
+		insertion,
+		range: {
+			begin,
+		},
+		type: "text-insert",
+	};
+};
+
+export const textSwap = (
+	insertion: string,
+	begin: number,
+	end: number,
+): TextSwapMutation => {
+	return {
+		insertion,
+		range: {
+			begin,
+			end,
+		},
+		type: "text-swap",
+	};
+};

--- a/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
+++ b/src/mutators/builtIn/fixIncompleteTypes/fixIncompleteReturnTypes/index.ts
@@ -2,7 +2,13 @@ import { Mutation } from "automutate";
 import * as tsutils from "ts-api-utils";
 import ts from "typescript";
 
+import { joinIntoType } from "../../../../mutations/aliasing/joinIntoType.js";
+import {
+	collectRawTypesFromTypes,
+	findMissingTypes,
+} from "../../../../mutations/collecting.js";
 import { createTypeAdditionMutation } from "../../../../mutations/creators.js";
+import { textSwap } from "../../../../mutations/text-mutations.js";
 import { isNotUndefined } from "../../../../shared/arrays.js";
 import {
 	FileMutationsRequest,
@@ -12,7 +18,10 @@ import {
 	FunctionLikeDeclarationWithType,
 	isNodeWithType,
 } from "../../../../shared/nodeTypes.js";
-import { getTypeAtLocationIfNotError } from "../../../../shared/types.js";
+import {
+	getTypeAtLocationIfNotError,
+	isTypeBuiltIn,
+} from "../../../../shared/types.js";
 import { collectMutationsFromNodes } from "../../../collectMutationsFromNodes.js";
 import { collectReturningNodeExpressions } from "../../fixStrictNonNullAssertions/fixStrictNonNullAssertionReturnTypes/collectReturningNodeExpressions.js";
 
@@ -47,6 +56,105 @@ const visitFunctionWithBody = (
 		.map((node) => getTypeAtLocationIfNotError(request, node))
 		.filter(isNotUndefined);
 
+	const isAsyncFunction = node.modifiers?.some((modifier) =>
+		tsutils.isAsyncKeyword(modifier),
+	);
+
+	if (isAsyncFunction) {
+		const returnType = getReturnTypeForAsyncFunction(
+			declaredType,
+			returnedTypes,
+			request,
+		);
+
+		if (returnType) {
+			return textSwap(returnType, node.type.pos, node.type.end);
+		} else {
+			return undefined;
+		}
+	}
+
 	// Add later-returned types to the node's type declaration if necessary
 	return createTypeAdditionMutation(request, node, declaredType, returnedTypes);
+};
+
+/**
+ * Async function's return type needs to be global Promise.
+ * It can't be `Promise<boolean> | Promise<string>`, but instead it needs to be `Promise<boolean | string>`.
+ * This function tries to collect all type arguments needed and then it wraps those inside `Promise`.
+ */
+const getReturnTypeForAsyncFunction = (
+	declaredType: ts.Type,
+	returnedTypes: ts.Type[],
+	request: FileMutationsRequest,
+): string | undefined => {
+	const typeChecker = request.services.program.getTypeChecker();
+
+	const declaredTypes = getRawUnwrappedTypes(
+		[declaredType],
+		request,
+		typeChecker,
+	);
+
+	const rawUnwrappedAssigned = getRawUnwrappedTypes(
+		returnedTypes,
+		request,
+		typeChecker,
+	);
+
+	// Subtract the above to find any types assigned but not declared
+	const missingTypes = findMissingTypes(
+		request,
+		rawUnwrappedAssigned,
+		declaredTypes,
+	);
+
+	// If nothing is missing, rejoice! The type was already fine.
+	if (missingTypes.size === 0) {
+		return undefined;
+	}
+
+	// Join the missing types into a type string to declare
+	const newTypeAlias = joinIntoType(
+		new Set([...declaredTypes, ...missingTypes]),
+		request,
+	);
+
+	return ` Promise<${newTypeAlias}>`;
+};
+
+/** Unwraps promises to their type arguments and collects all of those types together. */
+const getRawUnwrappedTypes = (
+	startingTypes: readonly ts.Type[],
+	request: FileMutationsRequest,
+	typeChecker: ts.TypeChecker,
+): Set<ts.Type> => {
+	const raw = collectRawTypesFromTypes(request, startingTypes);
+	const unwrapped = getUnwrappedTypes(raw, typeChecker);
+	const rawFromUnwrapped = collectRawTypesFromTypes(request, unwrapped);
+	return rawFromUnwrapped;
+};
+
+/** If type is Promise, return its type arguments. Otherwise, use original type. */
+const getUnwrappedTypes = (
+	types: Set<ts.Type>,
+	typeChecker: ts.TypeChecker,
+): ts.Type[] => {
+	return [...types]
+		.flatMap((type) => {
+			const startsWithPromise = typeChecker
+				.typeToString(typeChecker.getBaseTypeOfLiteralType(type))
+				.startsWith("Promise<");
+
+			if (
+				startsWithPromise &&
+				isTypeBuiltIn(type) &&
+				tsutils.isTypeReference(type)
+			) {
+				return type.typeArguments;
+			} else {
+				return type;
+			}
+		})
+		.filter((x) => !!x);
 };

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -110,6 +110,10 @@
 		return Promise.resolve("");
 	}
 
+	function resolveDifferentType(url: string): Promise<string> | Promise<boolean> {
+		return Promise.resolve(false);
+	}
+
 	const returnsBigInt = (): string | bigint => {
 		return BigInt("123");
 	};

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -110,6 +110,23 @@
 		return Promise.resolve("");
 	}
 
+	async function resolveDifferentTypeAsync(url: string): Promise<string | boolean> {
+		return Promise.resolve(false);
+	}
+
+	async function resolveDifferentTypeAsync2(url: string): Promise<string | undefined | number> {
+		const something: Promise<number | undefined> | undefined = undefined;
+		return something;
+	}
+
+	async function resolveDifferentComplexType(url: string): Promise<string | { value: string; key: number; }> {
+		const something: Promise<{ value: string; key: number }> = Promise.resolve({
+			value: "ABC",
+			key: 123,
+		});
+		return something;
+	}
+
 	function resolveDifferentType(url: string): Promise<string> | Promise<boolean> {
 		return Promise.resolve(false);
 	}

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -85,20 +85,18 @@
 		return "";
 	};
 
-// @ts-expect-error -- TODO: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<boolean>'?
-	async function navigateTo(): Promise<boolean> | boolean {
+	async function navigateTo(): Promise<boolean> {
 		return await new Promise(() => "");
 	}
 
 	function navigateByUrl(url: string): Promise<boolean>;
 
-// @ts-expect-error -- TODO: Function implementation name must be 'navigateByUrl'. The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<boolean>'?
-	async function navigateTo3(): Promise<boolean> | boolean {
+// @ts-expect-error -- TODO: Function implementation name must be 'navigateByUrl'.
+	async function navigateTo3(): Promise<boolean> {
 		return await navigateByUrl("");
 	}
 
-// @ts-expect-error -- TODO: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<boolean>'?
-	async function navigateTo2(): Promise<boolean> | boolean {
+	async function navigateTo2(): Promise<boolean> {
 		const navigated = await navigateByUrl("");
 		return navigated;
 	}

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -110,6 +110,10 @@
 		return Promise.resolve("");
 	}
 
+	async function returnPromiseWithAny(): Promise<any> {
+		return Promise.resolve("");
+	}
+
 	async function resolveDifferentTypeAsync(url: string): Promise<string | boolean> {
 		return Promise.resolve(false);
 	}

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -114,6 +114,15 @@
 		return Promise.resolve(false);
 	}
 
+	function resolveDifferentType2(url: string): Promise<string> | Promise<number | undefined> | undefined {
+		const something: Promise<number | undefined> | undefined = undefined;
+		return something;
+	}
+
+	function resolveDifferentType3(url: string): Promise<string> | string | Promise<boolean> {
+		return Promise.resolve(false);
+	}
+
 	const returnsBigInt = (): string | bigint => {
 		return BigInt("123");
 	};

--- a/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/expected.ts
@@ -89,9 +89,10 @@
 		return await new Promise(() => "");
 	}
 
-	function navigateByUrl(url: string): Promise<boolean>;
+	function navigateByUrl(url: string): Promise<boolean> {
+		return Promise.resolve(false);
+	}
 
-// @ts-expect-error -- TODO: Function implementation name must be 'navigateByUrl'.
 	async function navigateTo3(): Promise<boolean> {
 		return await navigateByUrl("");
 	}

--- a/test/cases/fixes/incompleteTypes/returnTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/original.ts
@@ -114,6 +114,15 @@
 		return Promise.resolve(false);
 	}
 
+	function resolveDifferentType2(url: string): Promise<string> {
+		const something: Promise<number | undefined> = undefined;
+		return something;
+	}
+
+	function resolveDifferentType3(url: string): Promise<string> | string {
+		return Promise.resolve(false);
+	}
+
 	const returnsBigInt = (): string => {
 		return BigInt("123");
 	};

--- a/test/cases/fixes/incompleteTypes/returnTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/original.ts
@@ -110,6 +110,23 @@
 		return Promise.resolve("");
 	}
 
+	async function resolveDifferentTypeAsync(url: string): Promise<string> {
+		return Promise.resolve(false);
+	}
+
+	async function resolveDifferentTypeAsync2(url: string): Promise<string> {
+		const something: Promise<number | undefined> = undefined;
+		return something;
+	}
+
+	async function resolveDifferentComplexType(url: string): Promise<string> {
+		const something: Promise<{ value: string; key: number }> = Promise.resolve({
+			value: "ABC",
+			key: 123,
+		});
+		return something;
+	}
+
 	function resolveDifferentType(url: string): Promise<string> {
 		return Promise.resolve(false);
 	}

--- a/test/cases/fixes/incompleteTypes/returnTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/original.ts
@@ -89,7 +89,9 @@
 		return await new Promise(() => "");
 	}
 
-	function navigateByUrl(url: string): Promise<boolean>;
+	function navigateByUrl(url: string): Promise<boolean> {
+		return Promise.resolve(false);
+	}
 
 	async function navigateTo3(): Promise<boolean> {
 		return await navigateByUrl("");

--- a/test/cases/fixes/incompleteTypes/returnTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/original.ts
@@ -110,6 +110,10 @@
 		return Promise.resolve("");
 	}
 
+	function resolveDifferentType(url: string): Promise<string> {
+		return Promise.resolve(false);
+	}
+
 	const returnsBigInt = (): string => {
 		return BigInt("123");
 	};

--- a/test/cases/fixes/incompleteTypes/returnTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/returnTypes/original.ts
@@ -110,6 +110,10 @@
 		return Promise.resolve("");
 	}
 
+	async function returnPromiseWithAny(): Promise<any> {
+		return Promise.resolve("");
+	}
+
 	async function resolveDifferentTypeAsync(url: string): Promise<string> {
 		return Promise.resolve(false);
 	}

--- a/test/fixIncompleteTypes.test.ts
+++ b/test/fixIncompleteTypes.test.ts
@@ -61,7 +61,7 @@ describe("Incomplete types", () => {
 			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
 		expect(options).toMatchSnapshot("options");
-	});
+	}, 50_000);
 
 	it("property declaration types", async () => {
 		const caseDir = path.join(
@@ -188,7 +188,7 @@ describe("Incomplete types", () => {
 			await runMutationTest(caseDir);
 		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
 		expect(options).toMatchSnapshot("options");
-	});
+	}, 50_000);
 
 	it("variable types", async () => {
 		const caseDir = path.join(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1494
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Wrap inside Promise, if one of the existing types mentions Promise.