### PR TITLE
chore: use weekly schedule with renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"automerge": true,
-	"extends": ["config:best-practices", "replacements:all"],
+	"extends": ["config:best-practices", "schedule:weekly"],
 	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
 	"minimumReleaseAge": "3 days",


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000 
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I'm proposing using or at least using for a some time, weekly scheduling with renovate. Now it feels that the master is spammed with the constant updates every day.

"replacements:all" is already included in "config:best-practices" ([config:best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices) -> [config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended))
