### PR TITLE
chore: add test coverage for incompleteTypes and Sets

### DIFF
--- a/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
@@ -191,4 +191,12 @@
 	let returnsStringOrNumber: (() => string) | (() => number);
 	returnsStringOrNumber = () => "";
 	returnsStringOrNumber = () => 0;
+
+	// Sets
+
+	function collector(collection: ReadonlySet<{ value: string }>) {
+		const collection2: Set<number> | Set<{ value: string; }> = new Set(collection);
+		const collection3: ReadonlySet<number> | Set<{ value: string; }> = new Set(collection);
+		const collection4: Set<any> = new Set(collection);
+	}
 })();

--- a/test/cases/fixes/incompleteTypes/variableTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/variableTypes/original.ts
@@ -185,4 +185,12 @@
 	let returnsStringOrNumber: Function;
 	returnsStringOrNumber = () => "";
 	returnsStringOrNumber = () => 0;
+
+	// Sets
+
+	function collector(collection: ReadonlySet<{ value: string }>) {
+		const collection2: Set<number> = new Set(collection);
+		const collection3: ReadonlySet<number> = new Set(collection);
+		const collection4: Set<any> = new Set(collection);
+	}
 })();


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1519
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Added some simple test cases
