### PR TITLE
chore: update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,24 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"automerge": true,
-	"extends": ["config:best-practices", "replacements:all"],
+	"extends": ["config:best-practices"],
 	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["* 0-3 1 * *"]
+	},
 	"minimumReleaseAge": "3 days",
+	"packageRules": [
+		{
+			"description": "Update patch versions monthly",
+			"enabled": true,
+			"extends": ["schedule:monthly"],
+			"matchUpdateTypes": ["patch"]
+		}
+	],
+	"patch": {
+		"enabled": false
+	},
 	"postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This partly does what this comment suggested https://github.com/JoshuaKGoldberg/TypeStat/pull/2231#issuecomment-2682006443 . 

I added few more rules, that I can remove if they feel unnecessary:

- once a month "package lock" will be updated, meaning the deep dependencies are refreshed (Schedule once a month on the first day of the month before 4 AM.) 
- once a month patch versions are updated, so that we will get bug fixes eventually