### PR TITLE
test: fix tests to actually test parameter wrapping

### DIFF
--- a/src/mutations/codeFixes/creation.test.ts
+++ b/src/mutations/codeFixes/creation.test.ts
@@ -1,0 +1,51 @@
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { simplifyTextChanges } from "./creation.js";
+
+describe("simplifyTextChanges", () => {
+	it("should not mangle two changes together", () => {
+		// This example is from https://github.com/JoshuaKGoldberg/TypeStat/issues/256
+		const changes: ts.TextChange[] = [
+			{
+				newText: "(",
+				span: {
+					length: 0,
+					start: 1405,
+				},
+			},
+			{
+				newText: ": number",
+				span: {
+					length: 0,
+					start: 1411,
+				},
+			},
+			{
+				newText: ")",
+				span: {
+					length: 0,
+					start: 1411,
+				},
+			},
+		];
+
+		const result = simplifyTextChanges(changes);
+		expect(result).toStrictEqual([
+			{
+				newText: "(",
+				span: {
+					length: 0,
+					start: 1405,
+				},
+			},
+			{
+				newText: ": number)",
+				span: {
+					length: 0,
+					start: 1411,
+				},
+			},
+		]);
+	});
+});

--- a/src/mutations/codeFixes/creation.ts
+++ b/src/mutations/codeFixes/creation.ts
@@ -67,7 +67,7 @@ export const createCodeFixCreationMutation = (
  * for the case of two text changes with the same span start.
  * @see https://github.com/JoshuaKGoldberg/TypeStat/issues/256
  */
-const simplifyTextChanges = (textChanges: readonly ts.TextChange[]) => {
+export const simplifyTextChanges = (textChanges: readonly ts.TextChange[]) => {
 	if (textChanges.length === 0 || isOnlyParenthesis(textChanges)) {
 		return undefined;
 	}

--- a/test/cases/fixes/noImplicitAny/parameters/expected.ts
+++ b/test/cases/fixes/noImplicitAny/parameters/expected.ts
@@ -65,9 +65,19 @@
 		console.log(char, index);
 	});
 
+	// prettier adds parenthesis here, but we want codefix to add those
+	// prettier-ignore
 	const needsWrapping = (count: number) => `${count}lbs`;
 	needsWrapping(1.234567);
 
 	const needsNoWrapping = (count: number) => `${count}lbs`;
 	needsNoWrapping(1.234567);
+
+	// prettier adds parenthesis here, but we want codefix to add those
+	// prettier-ignore
+	const addSpan = (el: HTMLDivElement) => {
+		el.appendChild(document.createElement("span"));
+	};
+
+	addSpan(document.createElement("div"));
 })();

--- a/test/cases/fixes/noImplicitAny/parameters/original.ts
+++ b/test/cases/fixes/noImplicitAny/parameters/original.ts
@@ -59,9 +59,19 @@
 		console.log(char, index);
 	});
 
-	const needsWrapping = (count) => `${count}lbs`;
+	// prettier adds parenthesis here, but we want codefix to add those
+	// prettier-ignore
+	const needsWrapping = count => `${count}lbs`;
 	needsWrapping(1.234567);
 
 	const needsNoWrapping = (count) => `${count}lbs`;
 	needsNoWrapping(1.234567);
+
+	// prettier adds parenthesis here, but we want codefix to add those
+	// prettier-ignore
+	const addSpan = el => {
+		el.appendChild(document.createElement("span"));
+	};
+
+	addSpan(document.createElement("div"));
 })();


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: related to #256
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I noticed that the test did not actually test previous issue anymore, because formatter had fixed the code and added parenthesis already. I also added unit test for `simplifyTextChanges`. I was fixing another issue and just noticed that I broke this code, but the tests were still passing happily.
