### PR TITLE
test: cover incomplete parameter call types

### DIFF
--- a/test/__snapshots__/fixIncompleteTypes.test.ts.snap
+++ b/test/__snapshots__/fixIncompleteTypes.test.ts.snap
@@ -1453,6 +1453,105 @@ exports[`Incomplete types > parameter types > options 1`] = `
 ]"
 `;
 
+exports[`Incomplete types > parameter types from calls > options 1`] = `
+"[
+  {
+    "cleanups": {
+      "suppressTypeErrors": true
+    },
+    "files": {
+      "above": "",
+      "below": "",
+      "renameExtensions": false
+    },
+    "filters": [],
+    "fixes": {
+      "importExtensions": false,
+      "incompleteTypes": true,
+      "missingProperties": false,
+      "noImplicitAny": false,
+      "noImplicitThis": false,
+      "noInferableTypes": false,
+      "strictNonNullAssertions": false
+    },
+    "hints": {
+      "react": {
+        "propTypes": "whenRequired",
+        "propTypesOptionality": "asWritten"
+      }
+    },
+    "include": [
+      "<rootDir>/actual.ts"
+    ],
+    "mutators": [
+      [
+        "fixImportExtensions",
+        null
+      ],
+      [
+        "fixIncompleteTypes",
+        null
+      ],
+      [
+        "fixMissingProperties",
+        null
+      ],
+      [
+        "fixNoImplicitAny",
+        null
+      ],
+      [
+        "fixNoImplicitThis",
+        null
+      ],
+      [
+        "fixNoInferableTypes",
+        null
+      ],
+      [
+        "fixStrictNonNullAssertions",
+        null
+      ]
+    ],
+    "output": {},
+    "package": {
+      "directory": "<rootDir>",
+      "file": "<rootDir>/package.json"
+    },
+    "parsedTsConfig": {
+      "options": {
+        "configFilePath": "<rootDir>/tsconfig.json",
+        "noEmit": true,
+        "noImplicitAny": false,
+        "noImplicitThis": false,
+        "strictNullChecks": false
+      },
+      "fileNames": [
+        "<rootDir>/actual.ts"
+      ],
+      "typeAcquisition": {
+        "enable": false,
+        "include": [],
+        "exclude": []
+      },
+      "raw": {
+        "files": [
+          "actual.ts"
+        ]
+      },
+      "errors": [],
+      "wildcardDirectories": {},
+      "compileOnSave": false
+    },
+    "postProcess": {
+      "shell": []
+    },
+    "projectPath": "<rootDir>/tsconfig.json",
+    "types": {}
+  }
+]"
+`;
+
 exports[`Incomplete types > property declaration types > options 1`] = `
 "[
   {

--- a/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/expected.ts
+++ b/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/expected.ts
@@ -1,0 +1,8 @@
+(function () {
+	function receivesPair(text: string | number, enabled: boolean | string): void {
+		console.log(text, enabled);
+	}
+
+	receivesPair("known", true);
+	receivesPair(123, "yes");
+})();

--- a/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/original.ts
+++ b/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/original.ts
@@ -1,0 +1,8 @@
+(function () {
+	function receivesPair(text: string, enabled: boolean): void {
+		console.log(text, enabled);
+	}
+
+	receivesPair("known", true);
+	receivesPair(123, "yes");
+})();

--- a/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/tsconfig.json
+++ b/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"files": ["actual.ts"]
+}

--- a/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/typestat.json
+++ b/test/cases/fixes/incompleteTypes/parameterTypesFromCalls/typestat.json
@@ -1,0 +1,8 @@
+{
+	"cleanups": {
+		"suppressTypeErrors": true
+	},
+	"fixes": {
+		"incompleteTypes": true
+	}
+}

--- a/test/fixIncompleteTypes.test.ts
+++ b/test/fixIncompleteTypes.test.ts
@@ -63,6 +63,17 @@ describe("Incomplete types", () => {
 		expect(options).toMatchSnapshot("options");
 	}, 50_000);
 
+	it("parameter types from calls", async () => {
+		const caseDir = path.join(
+			dirname,
+			"cases/fixes/incompleteTypes/parameterTypesFromCalls",
+		);
+		const { actualContent, expectedFilePath, options } =
+			await runMutationTest(caseDir);
+		await expect(actualContent).toMatchFileSnapshot(expectedFilePath);
+		expect(options).toMatchSnapshot("options");
+	}, 50_000);
+
 	it("property declaration types", async () => {
 		const caseDir = path.join(
 			dirname,


### PR DESCRIPTION
## Summary

- add a focused mutation test for incomplete parameter types inferred from call-site arguments
- cover multiple parameter indexes so `fixIncompleteParameterTypes` has to retain each collected calling type
- add the corresponding fixture config and options snapshot

Closes #763.

## Checks

- `npx pnpm@11.9.0 vitest run test/fixIncompleteTypes.test.ts`
- `npx pnpm@11.9.0 tsc`
- `npx pnpm@11.9.0 build && npx pnpm@11.9.0 lint`
