### PR TITLE
fix: parenthesize incomplete function type unions

### DIFF
--- a/src/mutations/collecting.ts
+++ b/src/mutations/collecting.ts
@@ -106,18 +106,9 @@ export const findMissingTypes = (
 		}
 	}
 
-	const declaredTypesContainFunction =
-		Array.from(declaredTypes).some(typeContainsFunction);
 	const remainingMissingTypes = new Set(assignedTypes);
 
 	const isAssignedTypeMissingFromDeclared = (assignedType: ts.Type) => {
-		// We ignore assigned function types when the declared type(s) include function(s).
-		// These non-assigned function types are more likely what users would consider bugs.
-		// For example, covariant functions might not be assignable, but should be fixed manually.
-		if (declaredTypesContainFunction && typeContainsFunction(assignedType)) {
-			return false;
-		}
-
 		// For each potential missing type:
 		for (const potentialParentType of declaredTypes) {
 			// If the potential parent type is unknown, then ignore it
@@ -149,6 +140,3 @@ export const findMissingTypes = (
 
 	return setSubtract(remainingMissingTypes, declaredTypes);
 };
-
-const typeContainsFunction = (type: ts.Type) =>
-	type.getCallSignatures().length !== 0;

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -57,6 +57,14 @@ export const createTypeAdditionMutation = (
 		return textSwap(` ${newTypeAlias}`, node.type.pos, node.type.end);
 	}
 
+	if (ts.isFunctionTypeNode(node.type)) {
+		return textSwap(
+			` (${node.type.getText(request.sourceFile)}) | ${newTypeAlias}`,
+			node.type.pos,
+			node.type.end,
+		);
+	}
+
 	// Create a mutation insertion that adds the missing types in
 	return textInsert(` | ${newTypeAlias}`, node.type.end);
 };

--- a/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
+++ b/test/cases/fixes/incompleteTypes/variableTypes/expected.ts
@@ -192,6 +192,10 @@
 	returnsStringOrNumber = () => "";
 	returnsStringOrNumber = () => 0;
 
+	let returnsEither: (() => string) | (() => number);
+	returnsEither = () => "";
+	returnsEither = () => 7;
+
 	// Sets
 
 	function collector(collection: ReadonlySet<{ value: string }>) {

--- a/test/cases/fixes/incompleteTypes/variableTypes/original.ts
+++ b/test/cases/fixes/incompleteTypes/variableTypes/original.ts
@@ -186,6 +186,10 @@
 	returnsStringOrNumber = () => "";
 	returnsStringOrNumber = () => 0;
 
+	let returnsEither: () => string;
+	returnsEither = () => "";
+	returnsEither = () => 7;
+
 	// Sets
 
 	function collector(collection: ReadonlySet<{ value: string }>) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #768
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/TypeStat/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/TypeStat/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Incomplete function type fixes now collect non-assignable function assignments instead of blanket-filtering them out. When adding those missing types to a function type annotation, TypeStat swaps the annotation so the original function type is parenthesized before the new union member is appended.

The existing assignability check still leaves compatible function assignments unchanged, including the historical `() => undefined` assignment under a declared `() => void` type.

A mutation regression covers the reported `() => string` plus `() => number` case and verifies the result is `(() => string) | (() => number)`.

## Validation

- `pnpm exec vitest run test/fixIncompleteTypes.test.ts` — 17 passed
- `pnpm run test` — 42 passed
- `pnpm run test:mutation` — 49 passed
- `pnpm run tsc`
- `pnpm run build`
- `pnpm run lint`

💖
